### PR TITLE
Use nullable reference types.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Authors>Antao Almada</Authors>
     <Copyright>Copyright 2019 Antao Almada</Copyright>
     <PackageIconUrl>https://user-images.githubusercontent.com/534533/49182105-390f3a80-f351-11e8-8e84-c785cddd2995.png</PackageIconUrl>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Features>strict</Features>
   </PropertyGroup>
 </Project>

--- a/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsEnumerable.cs
+++ b/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsEnumerable.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Wrap
     {
         public static Enumerable<T> AsEnumerable<T>(T[] source)
-        {
-            if (source is null) throw new ArgumentNullException(nameof(source));
-
-            return new Enumerable<T>(source);
-        }
+            => new Enumerable<T>(source);
 
         public struct Enumerable<T> 
             : IEnumerable<T>

--- a/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsReadOnlyCollection.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Wrap
     {
         public static ReadOnlyCollection<T> AsReadOnlyCollection<T>(T[] source)
-        {
-            if (source is null) throw new ArgumentNullException(nameof(source));
-
-            return new ReadOnlyCollection<T>(source);
-        }
+            => new ReadOnlyCollection<T>(source);
 
         public struct ReadOnlyCollection<T> 
             : IReadOnlyCollection<T>

--- a/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsReadOnlyList.cs
+++ b/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsReadOnlyList.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Wrap
     {
         public static ReadOnlyList<T> AsReadOnlyList<T>(T[] source)
-        {
-            if (source is null) throw new ArgumentNullException(nameof(source));
-
-            return new ReadOnlyList<T>(source);
-        }
+            => new ReadOnlyList<T>(source);
 
         public struct ReadOnlyList<T> 
             : IReadOnlyList<T>

--- a/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsValueEnumerable.cs
+++ b/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsValueEnumerable.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Wrap
     {
         public static ValueEnumerable<T> AsValueEnumerable<T>(T[] source)
-        {
-            if (source is null) throw new ArgumentNullException(nameof(source));
-
-            return new ValueEnumerable<T>(source);
-        }
+            => new ValueEnumerable<T>(source);
 
         public struct ValueEnumerable<T> 
             : IValueEnumerable<T, ValueEnumerable<T>.Enumerator>

--- a/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsValueReadOnlyCollection.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Wrap
     {
         public static ValueReadOnlyCollection<T> AsValueReadOnlyCollection<T>(T[] source)
-        {
-            if (source is null) throw new ArgumentNullException(nameof(source));
-
-            return new ValueReadOnlyCollection<T>(source);
-        }
+            => new ValueReadOnlyCollection<T>(source);
 
         public struct ValueReadOnlyCollection<T> 
             : IValueReadOnlyCollection<T, ValueReadOnlyCollection<T>.Enumerator>

--- a/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq.UnitTests/Utils/Wrappers/Wrap.AsValueReadOnlyList.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Wrap
     {
         public static ValueReadOnlyList<T> AsValueReadOnlyList<T>(T[] source)
-        {
-            if (source is null) throw new ArgumentNullException(nameof(source));
-
-            return new ValueReadOnlyList<T>(source);
-        }
+            => new ValueReadOnlyList<T>(source);
 
         public struct ValueReadOnlyList<T> 
             : IValueReadOnlyList<T, ValueReadOnlyList<T>.Enumerator>

--- a/NetFabric.Hyperlinq/Aggregation/Count/Count.Array.cs
+++ b/NetFabric.Hyperlinq/Aggregation/Count/Count.Array.cs
@@ -8,11 +8,7 @@ namespace NetFabric.Hyperlinq
             => source.Length;
 
         public static int Count<TSource>(this TSource[] source, Func<TSource, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return Count<TSource>(source, predicate, 0, source.Length);
-        }
+            => Count<TSource>(source, predicate, 0, source.Length);
 
         static int Count<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
@@ -27,16 +23,10 @@ namespace NetFabric.Hyperlinq
         }
 
         public static int Count<TSource>(this TSource[] source, Func<TSource, int, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return Count<TSource>(source, predicate, 0, source.Length);
-        }
+            => Count<TSource>(source, predicate, 0, source.Length);
 
         static int Count<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var count = 0;
             var end = skipCount + takeCount;
             for (var index = skipCount; index < end; index++)

--- a/NetFabric.Hyperlinq/Aggregation/Count/Count.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Aggregation/Count/Count.ReadOnlySpan.cs
@@ -9,8 +9,6 @@ namespace NetFabric.Hyperlinq
 
         public static int Count<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var count = 0;
             var length = source.Length;
             for (var index = 0; index < length; index++)
@@ -23,8 +21,6 @@ namespace NetFabric.Hyperlinq
 
         public static int Count<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var count = 0;
             var length = source.Length;
             for (var index = 0; index < length; index++)

--- a/NetFabric.Hyperlinq/Aggregation/Count/Count.Span.cs
+++ b/NetFabric.Hyperlinq/Aggregation/Count/Count.Span.cs
@@ -10,8 +10,6 @@ namespace NetFabric.Hyperlinq
 
         public static int Count<TSource>(this Span<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var count = 0;
             var length = source.Length;
             for (var index = 0; index < length; index++)
@@ -25,8 +23,6 @@ namespace NetFabric.Hyperlinq
 
         public static int Count<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var count = 0;
             var length = source.Length;
             for (var index = 0; index < length; index++)

--- a/NetFabric.Hyperlinq/Aggregation/Count/Count.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Aggregation/Count/Count.ValueReadOnlyList.cs
@@ -13,11 +13,7 @@ namespace NetFabric.Hyperlinq
         public static int Count<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-            
-            return Count<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => Count<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static int Count<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
@@ -36,11 +32,7 @@ namespace NetFabric.Hyperlinq
         public static int Count<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-            
-            return Count<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => Count<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static int Count<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Bindings.cs
@@ -106,7 +106,7 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this Dictionary<TKey, TValue> source)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TKey, TValue>, Dictionary<TKey, TValue>.Enumerator, KeyValuePair<TKey, TValue>, TKey, TValue>(new ValueWrapper<TKey, TValue>(source), (item => item.Key), (item => item.Value));
-        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this Dictionary<TKey, TValue> source, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this Dictionary<TKey, TValue> source, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TKey, TValue>, Dictionary<TKey, TValue>.Enumerator, KeyValuePair<TKey, TValue>, TKey, TValue>(new ValueWrapper<TKey, TValue>(source), (item => item.Key), (item => item.Value), comparer);
         public static Dictionary<TKey2, KeyValuePair<TKey, TValue>> ToDictionary<TKey, TValue, TKey2>(this Dictionary<TKey, TValue> source, Func<KeyValuePair<TKey, TValue>, TKey2> keySelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TKey, TValue>, Dictionary<TKey, TValue>.Enumerator, KeyValuePair<TKey, TValue>, TKey2>(new ValueWrapper<TKey, TValue>(source), keySelector);

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Keys.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Keys.Bindings.cs
@@ -34,7 +34,7 @@ namespace NetFabric.Hyperlinq
         public static bool Contains<TKey, TValue>(this Dictionary<TKey, TValue>.KeyCollection source, TKey value)
             => source.Contains(value);
 
-        public static bool Contains<TKey, TValue>(this Dictionary<TKey, TValue>.KeyCollection source, TKey value, IEqualityComparer<TKey> comparer)
+        public static bool Contains<TKey, TValue>(this Dictionary<TKey, TValue>.KeyCollection source, TKey value, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.Contains<ValueWrapper<TKey, TValue>, Dictionary<TKey, TValue>.KeyCollection.Enumerator, TKey>(new ValueWrapper<TKey, TValue>(source), value, comparer);
 
         public static ValueReadOnlyCollection.SelectEnumerable<ValueWrapper<TKey, TValue>, Dictionary<TKey, TValue>.KeyCollection.Enumerator, TKey, TResult> Select<TKey, TValue, TResult>(

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/HashSet.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/HashSet.Bindings.cs
@@ -106,11 +106,11 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this HashSet<TSource> source, Func<TSource, TKey> keySelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, HashSet<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector);
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this HashSet<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this HashSet<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, HashSet<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector, comparer);
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this HashSet<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, HashSet<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector);
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this HashSet<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this HashSet<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, HashSet<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector, comparer);
 
         public readonly struct ValueWrapper<TSource> 

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/LinkedList.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/LinkedList.Bindings.cs
@@ -106,11 +106,11 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this LinkedList<TSource> source, Func<TSource, TKey> keySelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, LinkedList<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector);
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this LinkedList<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this LinkedList<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, LinkedList<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector, comparer);
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this LinkedList<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, LinkedList<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector);
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this LinkedList<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this LinkedList<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, LinkedList<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector, comparer);
 
         public readonly struct ValueWrapper<TSource> 

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/List.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/List.Bindings.cs
@@ -105,11 +105,11 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this List<TSource> source, Func<TSource, TKey> keySelector)
             => ValueReadOnlyList.ToDictionary<ValueWrapper<TSource>, List<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector);
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this List<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this List<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyList.ToDictionary<ValueWrapper<TSource>, List<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector, comparer);
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this List<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             => ValueReadOnlyList.ToDictionary<ValueWrapper<TSource>, List<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector);
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this List<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this List<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyList.ToDictionary<ValueWrapper<TSource>, List<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector, comparer);
 
         public readonly struct ValueWrapper<TSource> 

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Queue.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Queue.Bindings.cs
@@ -106,11 +106,11 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Queue<TSource> source, Func<TSource, TKey> keySelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Queue<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector);
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Queue<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Queue<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Queue<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector, comparer);
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Queue<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Queue<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector);
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Queue<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Queue<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Queue<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector, comparer);
 
         public readonly struct ValueWrapper<TSource> 

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Bindings.cs
@@ -106,7 +106,7 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this SortedDictionary<TKey, TValue> source)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TKey, TValue>, SortedDictionary<TKey, TValue>.Enumerator, KeyValuePair<TKey, TValue>, TKey, TValue>(new ValueWrapper<TKey, TValue>(source), (item => item.Key), (item => item.Value));
-        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this SortedDictionary<TKey, TValue> source, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TValue> ToDictionary<TKey, TValue>(this SortedDictionary<TKey, TValue> source, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TKey, TValue>, SortedDictionary<TKey, TValue>.Enumerator, KeyValuePair<TKey, TValue>, TKey, TValue>(new ValueWrapper<TKey, TValue>(source), (item => item.Key), (item => item.Value), comparer);
         public static Dictionary<TKey2, KeyValuePair<TKey, TValue>> ToDictionary<TKey, TValue, TKey2>(this SortedDictionary<TKey, TValue> source, Func<KeyValuePair<TKey, TValue>, TKey2> keySelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TKey, TValue>, SortedDictionary<TKey, TValue>.Enumerator, KeyValuePair<TKey, TValue>, TKey2>(new ValueWrapper<TKey, TValue>(source), keySelector);

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Keys.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Keys.Bindings.cs
@@ -34,7 +34,7 @@ namespace NetFabric.Hyperlinq
         public static bool Contains<TKey, TValue>(this SortedDictionary<TKey, TValue>.KeyCollection source, TKey value)
             => source.Contains(value);
 
-        public static bool Contains<TKey, TValue>(this SortedDictionary<TKey, TValue>.KeyCollection source, TKey value, IEqualityComparer<TKey> comparer)
+        public static bool Contains<TKey, TValue>(this SortedDictionary<TKey, TValue>.KeyCollection source, TKey value, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.Contains<ValueWrapper<TKey, TValue>, SortedDictionary<TKey, TValue>.KeyCollection.Enumerator, TKey>(new ValueWrapper<TKey, TValue>(source), value, comparer);
 
         public static ValueReadOnlyCollection.SelectEnumerable<ValueWrapper<TKey, TValue>, SortedDictionary<TKey, TValue>.KeyCollection.Enumerator, TKey, TResult> Select<TKey, TValue, TResult>(

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedSet.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedSet.Bindings.cs
@@ -106,11 +106,11 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this SortedSet<TSource> source, Func<TSource, TKey> keySelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, SortedSet<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector);
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this SortedSet<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this SortedSet<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, SortedSet<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector, comparer);
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this SortedSet<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, SortedSet<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector);
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this SortedSet<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this SortedSet<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, SortedSet<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector, comparer);
 
         public readonly struct ValueWrapper<TSource> 

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Stack.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Stack.Bindings.cs
@@ -106,11 +106,11 @@ namespace NetFabric.Hyperlinq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Stack<TSource> source, Func<TSource, TKey> keySelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Stack<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector);
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Stack<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Stack<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Stack<TSource>.Enumerator, TSource, TKey>(new ValueWrapper<TSource>(source), keySelector, comparer);
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Stack<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Stack<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector);
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Stack<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Stack<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             => ValueReadOnlyCollection.ToDictionary<ValueWrapper<TSource>, Stack<TSource>.Enumerator, TSource, TKey, TElement>(new ValueWrapper<TSource>(source), keySelector, elementSelector, comparer);
 
         public readonly struct ValueWrapper<TSource> 

--- a/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.Array.cs
+++ b/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.Array.cs
@@ -6,36 +6,18 @@ namespace NetFabric.Hyperlinq
     public static partial class Array
     {
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
+            => ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Length);
 
-            return ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Length);
-        }
-
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
-            return ToDictionary<TSource, TKey>(source, keySelector, comparer, 0, source.Length);
-        }
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+            => ToDictionary<TSource, TKey>(source, keySelector, comparer, 0, source.Length);
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
+            => ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Length);
 
-            return ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Length);
-        }
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
+            => ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Length);
 
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
-            return ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Length);
-        }
-
-        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
+        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TSource>(source.Length, comparer);
             var end = skipCount + takeCount;
@@ -44,7 +26,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
+        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TElement>(source.Length, comparer);
             var end = skipCount + takeCount;
@@ -53,7 +35,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TSource>(source.Length, comparer);
             var end = skipCount + takeCount;
@@ -65,7 +47,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TElement>(source.Length, comparer);
             var end = skipCount + takeCount;
@@ -77,7 +59,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TSource>(source.Length, comparer);
             var end = skipCount + takeCount;
@@ -89,7 +71,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TElement>(source.Length, comparer);
             var end = skipCount + takeCount;

--- a/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ReadOnlySpan.cs
@@ -6,18 +6,10 @@ namespace NetFabric.Hyperlinq
     public static partial class ReadOnlySpanExtensions
     {
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this ReadOnlySpan<TSource> source, Func<TSource, TKey> keySelector)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
-            return ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Length);
-        }
+            => ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Length);
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this ReadOnlySpan<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
-            return ToDictionary<TSource, TKey>(source, keySelector, comparer, 0, source.Length);
-        }
+            => ToDictionary<TSource, TKey>(source, keySelector, comparer, 0, source.Length);
 
         static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this ReadOnlySpan<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
         {
@@ -29,20 +21,10 @@ namespace NetFabric.Hyperlinq
         }
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this ReadOnlySpan<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
-            return ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Length);
-        }
+            => ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Length);
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this ReadOnlySpan<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
-            return ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Length);
-        }
+            => ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Length);
 
         static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this ReadOnlySpan<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
         {

--- a/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.Span.cs
+++ b/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.Span.cs
@@ -6,20 +6,12 @@ namespace NetFabric.Hyperlinq
     public static partial class SpanExtensions
     {
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Span<TSource> source, Func<TSource, TKey> keySelector)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
+            => ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Length);
 
-            return ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Length);
-        }
+        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Span<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
+            => ToDictionary<TSource, TKey>(source, keySelector, comparer, 0, source.Length);
 
-        public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Span<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
-            return ToDictionary<TSource, TKey>(source, keySelector, comparer, 0, source.Length);
-        }
-
-        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Span<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
+        static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this Span<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TSource>(source.Length, comparer);
             var end = skipCount + takeCount;
@@ -29,22 +21,12 @@ namespace NetFabric.Hyperlinq
         }
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Span<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
+            => ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Length);
 
-            return ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Length);
-        }
+        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Span<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
+            => ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Length);
 
-        public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Span<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
-            return ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Length);
-        }
-
-        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Span<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
+        static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this Span<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, int skipCount, int takeCount)
         {
             var dictionary = new Dictionary<TKey, TElement>(source.Length, comparer);
             var end = skipCount + takeCount;

--- a/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ValueEnumerable.cs
@@ -10,12 +10,10 @@ namespace NetFabric.Hyperlinq
             where TEnumerator : struct, IEnumerator<TSource>
             => ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default);
 
-        public static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
             var dictionary = new Dictionary<TKey, TSource>(0, comparer);
             using (var enumerator = source.GetEnumerator())
             {
@@ -25,12 +23,10 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, Func<TSource, bool> predicate)
+        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, Func<TSource, bool> predicate)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
             var dictionary = new Dictionary<TKey, TSource>(0, comparer);
             using (var enumerator = source.GetEnumerator())
             {
@@ -43,12 +39,10 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, Func<TSource, int, bool> predicate)
+        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
             var dictionary = new Dictionary<TKey, TSource>(0, comparer);
             using (var enumerator = source.GetEnumerator())
             {
@@ -69,13 +63,10 @@ namespace NetFabric.Hyperlinq
             where TEnumerator : struct, IEnumerator<TSource>
             => ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
-        public static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
             var dictionary = new Dictionary<TKey, TElement>(0, comparer);
             using (var enumerator = source.GetEnumerator())
             {
@@ -85,13 +76,10 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, Func<TSource, bool> predicate)
+        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, Func<TSource, bool> predicate)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
             var dictionary = new Dictionary<TKey, TElement>(0, comparer);
             using (var enumerator = source.GetEnumerator())
             {
@@ -103,13 +91,10 @@ namespace NetFabric.Hyperlinq
             }
             return dictionary;
         }
-        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, Func<TSource, int, bool> predicate)
+        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
             var dictionary = new Dictionary<TKey, TElement>(0, comparer);
             using (var enumerator = source.GetEnumerator())
             {

--- a/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ValueReadOnlyCollection.cs
@@ -10,12 +10,10 @@ namespace NetFabric.Hyperlinq
             where TEnumerator : struct, IEnumerator<TSource>
             => ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default);
 
-        public static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
             var dictionary = new Dictionary<TKey, TSource>(source.Count, comparer);
             using (var enumerator = source.GetEnumerator())
             {
@@ -30,13 +28,10 @@ namespace NetFabric.Hyperlinq
             where TEnumerator : struct, IEnumerator<TSource>
             => ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default);
 
-        public static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
-
             var dictionary = new Dictionary<TKey, TElement>(source.Count, comparer);
             using (var enumerator = source.GetEnumerator())
             {

--- a/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ValueReadOnlyList.cs
@@ -8,42 +8,24 @@ namespace NetFabric.Hyperlinq
         public static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
+            => ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Count);
 
-            return ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, 0, source.Count);
-        }
-
-        public static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-
-            return ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, comparer, 0, source.Count);
-        }
+            => ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, comparer, 0, source.Count);
 
         public static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
+            => ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Count);
 
-            return ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, 0, source.Count);
-        }
-
-        public static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+        public static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (keySelector is null) ThrowHelper.ThrowArgumentNullException(nameof(keySelector));
-            if (elementSelector is null) ThrowHelper.ThrowArgumentNullException(nameof(elementSelector));
+            => ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Count);
 
-            return ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, 0, source.Count);
-        }
-
-        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
+        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -54,7 +36,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, int skipCount, int takeCount)
+        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -65,7 +47,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -79,7 +61,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, Func<TSource, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -93,7 +75,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TSource> ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(this TEnumerable source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -107,7 +89,7 @@ namespace NetFabric.Hyperlinq
             return dictionary;
         }
 
-        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
+        static Dictionary<TKey, TElement> ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(this TEnumerable source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {

--- a/NetFabric.Hyperlinq/Element/First/First.Array.cs
+++ b/NetFabric.Hyperlinq/Element/First/First.Array.cs
@@ -20,11 +20,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource First<TSource>(this TSource[] source, Func<TSource, bool> predicate) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref First<TSource>(source, predicate, 0, source.Length);
-        }
+            => ref First<TSource>(source, predicate, 0, source.Length);
 
         static ref readonly TSource First<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
@@ -38,11 +34,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource First<TSource>(this TSource[] source, Func<TSource, int, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref First<TSource>(source, predicate, 0, source.Length);
-        }
+            => ref First<TSource>(source, predicate, 0, source.Length);
 
         static ref readonly TSource First<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {
@@ -56,11 +48,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource First<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref First<TSource>(source, predicate, out index, 0, source.Length);
-        }
+            => ref First<TSource>(source, predicate, out index, 0, source.Length);
 
         static ref readonly TSource First<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index, int skipCount, int takeCount)
         {
@@ -89,11 +77,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource FirstOrDefault<TSource>(this TSource[] source, Func<TSource, bool> predicate) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref FirstOrDefault<TSource>(source, predicate, 0, source.Length);
-        }
+            => ref FirstOrDefault<TSource>(source, predicate, 0, source.Length);
 
         static ref readonly TSource FirstOrDefault<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
@@ -107,11 +91,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource FirstOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref FirstOrDefault<TSource>(source, predicate, 0, source.Length);
-        }
+            => ref FirstOrDefault<TSource>(source, predicate, 0, source.Length);
 
         static ref readonly TSource FirstOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {
@@ -125,11 +105,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource FirstOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref FirstOrDefault<TSource>(source, predicate, out index, 0, source.Length);
-        }
+            => ref FirstOrDefault<TSource>(source, predicate, out index, 0, source.Length);
 
         static ref readonly TSource FirstOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index, int skipCount, int takeCount)
         {

--- a/NetFabric.Hyperlinq/Element/First/First.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Element/First/First.ReadOnlySpan.cs
@@ -15,8 +15,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource First<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -29,8 +27,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource First<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -43,8 +39,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource First<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -65,8 +59,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource FirstOrDefault<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -78,8 +70,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource FirstOrDefault<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -91,8 +81,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource FirstOrDefault<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -120,8 +108,6 @@ namespace NetFabric.Hyperlinq
         public static TSource? FirstOrNull<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate, out int index)
             where TSource : struct
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {

--- a/NetFabric.Hyperlinq/Element/First/First.Span.cs
+++ b/NetFabric.Hyperlinq/Element/First/First.Span.cs
@@ -15,8 +15,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref TSource First<TSource>(this Span<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -29,8 +27,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref TSource First<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -43,8 +39,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref TSource First<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -65,8 +59,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource FirstOrDefault<TSource>(this Span<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -78,8 +70,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource FirstOrDefault<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -91,8 +81,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource FirstOrDefault<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -120,8 +108,6 @@ namespace NetFabric.Hyperlinq
         public static TSource? FirstOrNull<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate, out int index)
             where TSource : struct
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {

--- a/NetFabric.Hyperlinq/Element/First/First.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Element/First/First.ValueReadOnlyList.cs
@@ -39,20 +39,12 @@ namespace NetFabric.Hyperlinq
         public static (ElementResult Success, TSource Value) TryFirst<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return TryFirst<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => TryFirst<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         public static (int Index, TSource Value) TryFirst<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return TryFirst<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => TryFirst<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static (ElementResult Success, TSource Value) TryFirst<TEnumerable, TEnumerator, TSource>(this TEnumerable source, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>

--- a/NetFabric.Hyperlinq/Element/Single/Single.Array.cs
+++ b/NetFabric.Hyperlinq/Element/Single/Single.Array.cs
@@ -24,11 +24,8 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource Single<TSource>(this TSource[] source, Func<TSource, int, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
+            => ref Single<TSource>(source, predicate, 0, source.Length);
 
-            return ref Single<TSource>(source, predicate, 0, source.Length);
-        }
         static ref readonly TSource Single<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {
             var end = skipCount + takeCount;
@@ -51,11 +48,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource Single<TSource>(this TSource[] source, Func<TSource, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref Single<TSource>(source, predicate, 0, source.Length);
-        }
+            => ref Single<TSource>(source, predicate, 0, source.Length);
 
         static ref readonly TSource Single<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
@@ -79,11 +72,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource Single<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref Single<TSource>(source, predicate, out index, 0, source.Length);
-        }
+            => ref Single<TSource>(source, predicate, out index, 0, source.Length);
 
         static ref readonly TSource Single<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index, int skipCount, int takeCount)
         {
@@ -125,11 +114,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource SingleOrDefault<TSource>(this TSource[] source, Func<TSource, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref SingleOrDefault<TSource>(source, predicate, 0, source.Length);
-        }
+            => ref SingleOrDefault<TSource>(source, predicate, 0, source.Length);
 
         static ref readonly TSource SingleOrDefault<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
@@ -153,11 +138,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource SingleOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref SingleOrDefault<TSource>(source, predicate, 0, source.Length);
-        }
+            => ref SingleOrDefault<TSource>(source, predicate, 0, source.Length);
 
         static ref readonly TSource SingleOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {
@@ -181,11 +162,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static ref readonly TSource SingleOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ref SingleOrDefault<TSource>(source, predicate, out index, 0, source.Length);
-        }
+            => ref SingleOrDefault<TSource>(source, predicate, out index, 0, source.Length);
 
         static ref readonly TSource SingleOrDefault<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index, int skipCount, int takeCount)
         {
@@ -236,11 +213,7 @@ namespace NetFabric.Hyperlinq
 
         public static TSource? SingleOrNull<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index)
             where TSource : struct
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return SingleOrNull<TSource>(source, predicate, out index, 0, source.Length);
-        }
+            => SingleOrNull<TSource>(source, predicate, out index, 0, source.Length);
 
         static TSource? SingleOrNull<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, out int index, int skipCount, int takeCount)
             where TSource : struct

--- a/NetFabric.Hyperlinq/Element/Single/Single.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Element/Single/Single.ReadOnlySpan.cs
@@ -17,8 +17,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource Single<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -41,8 +39,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource Single<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -65,8 +61,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource Single<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -99,8 +93,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource SingleOrDefault<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -122,8 +114,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource SingleOrDefault<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -145,8 +135,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource SingleOrDefault<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -186,8 +174,6 @@ namespace NetFabric.Hyperlinq
         public static TSource? SingleOrNull<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate, out int index)
             where TSource : struct
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {

--- a/NetFabric.Hyperlinq/Element/Single/Single.Span.cs
+++ b/NetFabric.Hyperlinq/Element/Single/Single.Span.cs
@@ -17,8 +17,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref TSource Single<TSource>(this Span<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -41,8 +39,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref TSource Single<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -65,8 +61,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref TSource Single<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -99,8 +93,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource SingleOrDefault<TSource>(this Span<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -122,8 +114,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource SingleOrDefault<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -145,8 +135,6 @@ namespace NetFabric.Hyperlinq
 
         public static ref readonly TSource SingleOrDefault<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate, out int index)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {
@@ -186,8 +174,6 @@ namespace NetFabric.Hyperlinq
         public static TSource? SingleOrNull<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate, out int index)
             where TSource : struct
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (index = 0; index < length; index++)
             {

--- a/NetFabric.Hyperlinq/Element/Single/Single.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Element/Single/Single.ValueReadOnlyList.cs
@@ -38,20 +38,12 @@ namespace NetFabric.Hyperlinq
         public static (ElementResult Success, TSource Value) TrySingle<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return TrySingle<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => TrySingle<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         public static (int Index, TSource Value) TrySingle<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return TrySingle<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => TrySingle<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static (ElementResult Success, TSource Value) TrySingle<TEnumerable, TEnumerator, TSource>(this TEnumerable source, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>

--- a/NetFabric.Hyperlinq/Filtering/Where/Where.Array.cs
+++ b/NetFabric.Hyperlinq/Filtering/Where/Where.Array.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Array
     {
         public static WhereEnumerable<TSource> Where<TSource>(this TSource[] source, Func<TSource, bool> predicate) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return new WhereEnumerable<TSource>(source, predicate, 0, source.Length);
-        }
+            => new WhereEnumerable<TSource>(source, predicate, 0, source.Length);
 
         static WhereEnumerable<TSource> Where<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
             => new WhereEnumerable<TSource>(source, predicate, skipCount, takeCount);
@@ -128,11 +124,11 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => Array.ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => Array.ToDictionary<TSource, TKey>(source, keySelector, comparer, predicate, skipCount, takeCount);
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => Array.ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => Array.ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, predicate, skipCount, takeCount);
         }
     }

--- a/NetFabric.Hyperlinq/Filtering/Where/Where.Span.cs
+++ b/NetFabric.Hyperlinq/Filtering/Where/Where.Span.cs
@@ -5,11 +5,7 @@ namespace NetFabric.Hyperlinq
     public static partial class SpanExtensions
     {
         public static WhereEnumerable<TSource> Where<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return new WhereEnumerable<TSource>(source, predicate);
-        }
+            => new WhereEnumerable<TSource>(source, predicate);
 
         public readonly ref struct WhereEnumerable<TSource>
         {

--- a/NetFabric.Hyperlinq/Filtering/Where/Where.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Filtering/Where/Where.ValueEnumerable.cs
@@ -9,11 +9,7 @@ namespace NetFabric.Hyperlinq
         public static WhereEnumerable<TEnumerable, TEnumerator, TSource> Where<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return new WhereEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate);
-        }
+            => new WhereEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate);
 
         [GenericsTypeMapping("TEnumerable", typeof(WhereEnumerable<,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(WhereEnumerable<,,>.Enumerator))]
@@ -137,11 +133,11 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, predicate);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, comparer, predicate);
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, predicate);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, predicate);
         }
     }

--- a/NetFabric.Hyperlinq/Filtering/Where/Where.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Filtering/Where/Where.ValueReadOnlyList.cs
@@ -9,11 +9,7 @@ namespace NetFabric.Hyperlinq
         public static WhereEnumerable<TEnumerable, TEnumerator, TSource> Where<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return new WhereEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate, 0, source.Count);
-        }
+            => new WhereEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate, 0, source.Count);
 
         static WhereEnumerable<TEnumerable, TEnumerator, TSource> Where<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
@@ -149,11 +145,11 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, comparer, predicate, skipCount, takeCount);
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, predicate, skipCount, takeCount);
         }
     }

--- a/NetFabric.Hyperlinq/Filtering/WhereIndex/Where.Array.cs
+++ b/NetFabric.Hyperlinq/Filtering/WhereIndex/Where.Array.cs
@@ -7,11 +7,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Array
     {
         public static WhereIndexEnumerable<TSource> Where<TSource>(this TSource[] source, Func<TSource, int, bool> predicate) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return new WhereIndexEnumerable<TSource>(source, predicate, 0, source.Length);
-        }
+            => new WhereIndexEnumerable<TSource>(source, predicate, 0, source.Length);
 
         static WhereIndexEnumerable<TSource> Where<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
             => new WhereIndexEnumerable<TSource>(source, predicate, skipCount, takeCount);
@@ -132,11 +128,11 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => Array.ToDictionary<TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => Array.ToDictionary<TSource, TKey>(source, keySelector, comparer, predicate, skipCount, takeCount);
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => Array.ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => Array.ToDictionary<TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, predicate, skipCount, takeCount);
         }
     }

--- a/NetFabric.Hyperlinq/Filtering/WhereIndex/WhereIndex.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Filtering/WhereIndex/WhereIndex.ValueEnumerable.cs
@@ -9,11 +9,7 @@ namespace NetFabric.Hyperlinq
         public static WhereIndexEnumerable<TEnumerable, TEnumerator, TSource> Where<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return new WhereIndexEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate);
-        }
+            => new WhereIndexEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate);
 
         [GenericsTypeMapping("TEnumerable", typeof(WhereIndexEnumerable<,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(WhereIndexEnumerable<,,>.Enumerator))]
@@ -122,11 +118,11 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, predicate);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, comparer, predicate);
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, predicate);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => ValueEnumerable.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, predicate);
         }
     }

--- a/NetFabric.Hyperlinq/Filtering/WhereIndex/WhereIndex.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Filtering/WhereIndex/WhereIndex.ValueReadOnlyList.cs
@@ -9,11 +9,7 @@ namespace NetFabric.Hyperlinq
         public static WhereIndexEnumerable<TEnumerable, TEnumerator, TSource> Where<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return new WhereIndexEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate, 0, source.Count);
-        }
+            => new WhereIndexEnumerable<TEnumerable, TEnumerator, TSource>(in source, predicate, 0, source.Count);
 
         static WhereIndexEnumerable<TEnumerable, TEnumerator, TSource> Where<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
@@ -147,11 +143,11 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, comparer, predicate, skipCount, takeCount);
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, predicate, skipCount, takeCount);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, predicate, skipCount, takeCount);
         }
     }

--- a/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.Array.cs
+++ b/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.Array.cs
@@ -109,7 +109,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(0, comparer);
 
@@ -129,7 +129,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(0, comparer);
 

--- a/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.Span.cs
+++ b/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.Span.cs
@@ -9,12 +9,7 @@ namespace NetFabric.Hyperlinq
             this Span<TSource> source, 
             Func<TSource, long, bool> predicate, 
             Func<TSource, long, TResult> selector) 
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new WhereSelectEnumerable<TSource, TResult>(source, predicate, selector);
-        }
+            => new WhereSelectEnumerable<TSource, TResult>(source, predicate, selector);
 
         public readonly ref struct WhereSelectEnumerable<TSource, TResult>
         {

--- a/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.ValueEnumerable.cs
@@ -12,12 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, TResult> selector)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new WhereSelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, predicate, selector);
-        }
+            => new WhereSelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, predicate, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(WhereSelectEnumerable<,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(WhereSelectEnumerable<,,,>.Enumerator))]
@@ -108,7 +103,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(0, comparer);
 
@@ -130,7 +125,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(0, comparer);
 

--- a/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Filtering/WhereSelect/WhereSelect.ValueReadOnlyList.cs
@@ -12,12 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, TResult> selector)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new WhereSelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, predicate, selector, 0, source.Count);
-        }
+            => new WhereSelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, predicate, selector, 0, source.Count);
 
         internal static WhereSelectEnumerable<TEnumerable, TEnumerator, TSource, TResult> WhereSelect<TEnumerable, TEnumerator, TSource, TResult>(
             this TEnumerable source,
@@ -122,7 +117,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(0, comparer);
 
@@ -142,7 +137,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(0, comparer);
 

--- a/NetFabric.Hyperlinq/Generation/CreateValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Generation/CreateValueEnumerable.cs
@@ -8,11 +8,7 @@ namespace NetFabric.Hyperlinq
 {
         public static CreateValueEnumerable<TEnumerator, TSource> Create<TEnumerator, TSource>(Func<TEnumerator> getEnumerator) 
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if(getEnumerator is null) ThrowHelper.ThrowArgumentNullException(nameof(getEnumerator));
-
-            return new CreateValueEnumerable<TEnumerator, TSource>(getEnumerator);
-        }
+            => new CreateValueEnumerable<TEnumerator, TSource>(getEnumerator);
 
         [GenericsTypeMapping("TEnumerable", typeof(CreateValueEnumerable<,>))]
         public readonly struct CreateValueEnumerable<TEnumerator, TSource> 

--- a/NetFabric.Hyperlinq/Generation/Empty.cs
+++ b/NetFabric.Hyperlinq/Generation/Empty.cs
@@ -69,23 +69,23 @@ namespace NetFabric.Hyperlinq
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public EmptyEnumerable<TSource> Select<TResult>(Func<TSource, TResult> selector)
-                => selector is null ? ThrowHelper.ThrowArgumentNullException<EmptyEnumerable<TSource>>(nameof(selector)) : this;
+                => this;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public EmptyEnumerable<TSource> Select<TResult>(Func<TSource, int, TResult> selector)
-                => selector is null ? ThrowHelper.ThrowArgumentNullException<EmptyEnumerable<TSource>>(nameof(selector)) : this;
+                => this;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public EmptyEnumerable<TSource> SelectMany<TResult>(Func<TSource, IEnumerable<TResult>> selector)
-                => selector is null ? ThrowHelper.ThrowArgumentNullException<EmptyEnumerable<TSource>>(nameof(selector)) : this;
+                => this;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public EmptyEnumerable<TSource> Where(Func<TSource, bool> predicate)
-                => predicate is null ? ThrowHelper.ThrowArgumentNullException<EmptyEnumerable<TSource>>(nameof(predicate)) : this;
+                => this;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public EmptyEnumerable<TSource> Where(Func<TSource, int, bool> predicate)
-                => predicate is null ? ThrowHelper.ThrowArgumentNullException<EmptyEnumerable<TSource>>(nameof(predicate)) : this;
+                => this;
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public TSource First() => ThrowHelper.ThrowEmptySequence<TSource>();
@@ -110,11 +110,11 @@ namespace NetFabric.Hyperlinq
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public (bool Success, TSource Value) TryFirst(Func<TSource, bool> predicate) 
-                => predicate is null ? ThrowHelper.ThrowArgumentNullException<ValueTuple<bool, TSource>>(nameof(predicate)) : (false, default);
+                => (false, default);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public (int Index, TSource Value) TryFirst(Func<TSource, int, bool> predicate)
-                => predicate is null ? ThrowHelper.ThrowArgumentNullException<ValueTuple<int, TSource>>(nameof(predicate)) : (-1, default);
+                => (-1, default);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public TSource Single() => ThrowHelper.ThrowEmptySequence<TSource>();
@@ -139,11 +139,11 @@ namespace NetFabric.Hyperlinq
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public (bool Success, TSource Value) TrySingle(Func<TSource, bool> predicate) 
-                => predicate is null ? ThrowHelper.ThrowArgumentNullException<ValueTuple<bool, TSource>>(nameof(predicate)) : (false, default);
+                => (false, default);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public (int Index, TSource Value) TrySingle(Func<TSource, int, bool> predicate)
-                => predicate is null ? ThrowHelper.ThrowArgumentNullException<ValueTuple<int, TSource>>(nameof(predicate)) : (-1, default);
+                => (-1, default);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public TSource[] ToArray() => new TSource[0];
@@ -155,13 +155,13 @@ namespace NetFabric.Hyperlinq
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector) 
                 => new Dictionary<TKey, TSource>(0);
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer) 
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer) 
                 => new Dictionary<TKey, TSource>(0, comparer);
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector) 
                 => new Dictionary<TKey, TElement>(0);
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer) 
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer) 
                 => new Dictionary<TKey, TElement>(0, comparer);
         }
 
@@ -171,11 +171,11 @@ namespace NetFabric.Hyperlinq
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Count<TSource>(this EmptyEnumerable<TSource> source, Func<TSource, bool> predicate)
-            => predicate is null ? ThrowHelper.ThrowArgumentNullException<int>(nameof(predicate)) : 0;
+            => 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Count<TSource>(this EmptyEnumerable<TSource> source, Func<TSource, int, bool> predicate)
-            => predicate is null ? ThrowHelper.ThrowArgumentNullException<int>(nameof(predicate)) : 0;
+            => 0;
     }
 }
 

--- a/NetFabric.Hyperlinq/Generation/Range.cs
+++ b/NetFabric.Hyperlinq/Generation/Range.cs
@@ -116,7 +116,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, int> ToDictionary<TKey>(Func<int, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, int> ToDictionary<TKey>(Func<int, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, int> ToDictionary<TKey>(Func<int, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, int>(count, comparer);
 
@@ -129,7 +129,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<int, TKey> keySelector, Func<int, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<int, TKey> keySelector, Func<int, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<int, TKey> keySelector, Func<int, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(count, comparer);
 

--- a/NetFabric.Hyperlinq/Generation/Repeat.cs
+++ b/NetFabric.Hyperlinq/Generation/Repeat.cs
@@ -122,7 +122,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TSource>(count, comparer);
 
@@ -135,7 +135,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(count, comparer);
 

--- a/NetFabric.Hyperlinq/Generation/Return.cs
+++ b/NetFabric.Hyperlinq/Generation/Return.cs
@@ -112,12 +112,12 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => new Dictionary<TKey, TSource>(1, comparer) { { keySelector(value), value } };
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => new Dictionary<TKey, TElement>(1, comparer) { { keySelector(value), elementSelector(value) } };
         }
 

--- a/NetFabric.Hyperlinq/NetFabric.Hyperlinq.csproj
+++ b/NetFabric.Hyperlinq/NetFabric.Hyperlinq.csproj
@@ -9,6 +9,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <PackageTags>netfabric, hyperlinq, linq, enumeration, extensions, performance</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp2.1'">

--- a/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.ValueReadOnlyList.cs
@@ -141,11 +141,11 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, EqualityComparer<TKey>.Default, skipCount, takeCount);
-            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TSource> ToDictionary<TKey>(Func<TSource, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey>(source, keySelector, comparer, skipCount, takeCount);
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, EqualityComparer<TKey>.Default, skipCount, takeCount);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 => ValueReadOnlyList.ToDictionary<TEnumerable, TEnumerator, TSource, TKey, TElement>(source, keySelector, elementSelector, comparer, skipCount, takeCount);
         }
 
@@ -159,20 +159,12 @@ namespace NetFabric.Hyperlinq
         public static int Count<TEnumerable, TEnumerator, TSource>(this SkipTakeEnumerable<TEnumerable, TEnumerator, TSource> source, Func<TSource, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ValueReadOnlyList.Count<TEnumerable, TEnumerator, TSource>(source.source, predicate, source.skipCount, source.takeCount);
-        }
+            => ValueReadOnlyList.Count<TEnumerable, TEnumerator, TSource>(source.source, predicate, source.skipCount, source.takeCount);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int Count<TEnumerable, TEnumerator, TSource>(this SkipTakeEnumerable<TEnumerable, TEnumerator, TSource> source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return ValueReadOnlyList.Count<TEnumerable, TEnumerator, TSource>(source.source, predicate, source.skipCount, source.takeCount);
-        }
+            => ValueReadOnlyList.Count<TEnumerable, TEnumerator, TSource>(source.source, predicate, source.skipCount, source.takeCount);
     }
 }

--- a/NetFabric.Hyperlinq/Projection/Select/Select.Array.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.Array.cs
@@ -10,11 +10,7 @@ namespace NetFabric.Hyperlinq
         public static SelectEnumerable<TSource, TResult> Select<TSource, TResult>(
             this TSource[] source, 
             Func<TSource, TResult> selector)
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectEnumerable<TSource, TResult>(source, selector, 0, source.Length);
-        }
+            => new SelectEnumerable<TSource, TResult>(source, selector, 0, source.Length);
 
         static SelectEnumerable<TSource, TResult> Select<TSource, TResult>(
             this TSource[] source,
@@ -141,7 +137,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(source.Length, comparer);
 
@@ -158,7 +154,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(source.Length, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/Select/Select.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.ReadOnlySpan.cs
@@ -8,11 +8,7 @@ namespace NetFabric.Hyperlinq
         public static SelectEnumerable<TSource, TResult> Select<TSource, TResult>(
             this ReadOnlySpan<TSource> source, 
             Func<TSource, long, TResult> selector)
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectEnumerable<TSource, TResult>(in source, selector);
-        }
+            => new SelectEnumerable<TSource, TResult>(in source, selector);
 
         public readonly ref struct SelectEnumerable<TSource, TResult>
         {

--- a/NetFabric.Hyperlinq/Projection/Select/Select.Span.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.Span.cs
@@ -8,11 +8,7 @@ namespace NetFabric.Hyperlinq
         public static SelectEnumerable<TSource, TResult> Select<TSource, TResult>(
             this Span<TSource> source, 
             Func<TSource, long, TResult> selector)
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectEnumerable<TSource, TResult>(in source, selector);
-        }
+            => new SelectEnumerable<TSource, TResult>(in source, selector);
 
         public readonly ref struct SelectEnumerable<TSource, TResult>
         {

--- a/NetFabric.Hyperlinq/Projection/Select/Select.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.ValueEnumerable.cs
@@ -12,11 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, TResult> selector)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
-        }
+            => new SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectEnumerable<,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectEnumerable<,,,>.Enumerator))]
@@ -112,7 +108,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(0, comparer);
 
@@ -131,7 +127,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(0, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/Select/Select.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.ValueReadOnlyCollection.cs
@@ -12,11 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, TResult> selector)
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if(selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
-        }
+            => new SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectEnumerable<,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectEnumerable<,,,>.Enumerator))]
@@ -146,7 +142,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(source.Count, comparer);
 
@@ -165,7 +161,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(source.Count, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/Select/Select.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.ValueReadOnlyList.cs
@@ -12,11 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, TResult> selector)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if(selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector, 0, source.Count);
-        }
+            => new SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector, 0, source.Count);
 
         static SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult> Select<TEnumerable, TEnumerator, TSource, TResult>(
             this TEnumerable source,
@@ -182,7 +178,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(source.Count, comparer);
 
@@ -199,7 +195,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(source.Count, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.Array.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.Array.cs
@@ -10,11 +10,7 @@ namespace NetFabric.Hyperlinq
         public static SelectIndexEnumerable<TSource, TResult> Select<TSource, TResult>(
             this TSource[] source, 
             Func<TSource, int, TResult> selector)
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectIndexEnumerable<TSource, TResult>(source, selector, 0, source.Length);
-        }
+            => new SelectIndexEnumerable<TSource, TResult>(source, selector, 0, source.Length);
 
         static SelectIndexEnumerable<TSource, TResult> Select<TSource, TResult>(
             this TSource[] source,
@@ -138,7 +134,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(source.Length, comparer);
 
@@ -155,7 +151,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(source.Length, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ValueEnumerable.cs
@@ -12,11 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, int, TResult> selector)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectIndexEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
-        }
+            => new SelectIndexEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectIndexEnumerable<,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectIndexEnumerable<,,,>.Enumerator))]
@@ -123,7 +119,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(0, comparer);
 
@@ -145,7 +141,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(0, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ValueReadOnlyCollection.cs
@@ -12,11 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, int, TResult> selector)
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if(selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectIndexEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
-        }
+            => new SelectIndexEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectIndexEnumerable<,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectIndexEnumerable<,,,>.Enumerator))]
@@ -157,7 +153,7 @@ namespace NetFabric.Hyperlinq
 
                 public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                     => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-                public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+                public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
                 {
                     var dictionary = new Dictionary<TKey, TResult>(source.Count, comparer);
 
@@ -176,7 +172,7 @@ namespace NetFabric.Hyperlinq
 
                 public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                     => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-                public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+                public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
                 {
                     var dictionary = new Dictionary<TKey, TElement>(source.Count, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ValueReadOnlyList.cs
@@ -12,11 +12,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, int, TResult> selector)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if(selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectIndexEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector, 0, source.Count);
-        }
+            => new SelectIndexEnumerable<TEnumerable, TEnumerator, TSource, TResult>(in source, selector, 0, source.Count);
 
         static SelectIndexEnumerable<TEnumerable, TEnumerator, TSource, TResult> Select<TEnumerable, TEnumerator, TSource, TResult>(
             this TEnumerable source,
@@ -173,7 +169,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector)
                 => ToDictionary<TKey>(keySelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TResult> ToDictionary<TKey>(Func<TResult, TKey> keySelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TResult>(source.Count, comparer);
 
@@ -190,7 +186,7 @@ namespace NetFabric.Hyperlinq
 
             public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector)
                 => ToDictionary<TKey, TElement>(keySelector, elementSelector, EqualityComparer<TKey>.Default);
-            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey> comparer)
+            public Dictionary<TKey, TElement> ToDictionary<TKey, TElement>(Func<TResult, TKey> keySelector, Func<TResult, TElement> elementSelector, IEqualityComparer<TKey>? comparer)
             {
                 var dictionary = new Dictionary<TKey, TElement>(source.Count, comparer);
 

--- a/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.Array.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.Array.cs
@@ -11,11 +11,7 @@ namespace NetFabric.Hyperlinq
             Func<TSource, TSubEnumerable> selector)
             where TSubEnumerable : IValueEnumerable<TResult, TSubEnumerator>
             where TSubEnumerator : struct, IEnumerator<TResult>
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectManyEnumerable<TSource, TSubEnumerable, TSubEnumerator, TResult>(source, selector);
-        }
+            => new SelectManyEnumerable<TSource, TSubEnumerable, TSubEnumerator, TResult>(source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectManyEnumerable<,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectManyEnumerable<,,,>.Enumerator))]

--- a/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.ReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.ReadOnlyList.cs
@@ -12,11 +12,7 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IReadOnlyList<TSource>
             where TSubEnumerable : IValueEnumerable<TResult, TSubEnumerator>
             where TSubEnumerator : struct, IEnumerator<TResult>
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectManyEnumerable<TEnumerable, TSource, TSubEnumerable, TSubEnumerator, TResult>(source, selector);
-        }
+            => new SelectManyEnumerable<TEnumerable, TSource, TSubEnumerable, TSubEnumerator, TResult>(source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectManyEnumerable<,,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectManyEnumerable<,,,,>.Enumerator))]

--- a/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.ValueEnumerable.cs
@@ -13,11 +13,7 @@ namespace NetFabric.Hyperlinq
             where TEnumerator : struct, IEnumerator<TSource>
             where TSubEnumerable : IValueEnumerable<TResult, TSubEnumerator>
             where TSubEnumerator : struct, IEnumerator<TResult>
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectManyEnumerable<TEnumerable, TEnumerator, TSource, TSubEnumerable, TSubEnumerator, TResult>(in source, selector);
-        }
+            => new SelectManyEnumerable<TEnumerable, TEnumerator, TSource, TSubEnumerable, TSubEnumerator, TResult>(in source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectManyEnumerable<,,,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectManyEnumerable<,,,,,>.Enumerator))]

--- a/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectMany/SelectMany.ValueReadOnlyList.cs
@@ -13,11 +13,7 @@ namespace NetFabric.Hyperlinq
             where TEnumerator : struct, IEnumerator<TSource>
             where TSubEnumerable : IValueEnumerable<TResult, TSubEnumerator>
             where TSubEnumerator : struct, IEnumerator<TResult>
-        {
-            if (selector is null) ThrowHelper.ThrowArgumentNullException(nameof(selector));
-
-            return new SelectManyEnumerable<TEnumerable, TEnumerator, TSource, TSubEnumerable, TSubEnumerator, TResult>(in source, selector);
-        }
+            => new SelectManyEnumerable<TEnumerable, TEnumerator, TSource, TSubEnumerable, TSubEnumerator, TResult>(in source, selector);
 
         [GenericsTypeMapping("TEnumerable", typeof(SelectManyEnumerable<,,,,,>))]
         [GenericsTypeMapping("TEnumerator", typeof(SelectManyEnumerable<,,,,,>.Enumerator))]

--- a/NetFabric.Hyperlinq/Quantifier/All/All.Array.cs
+++ b/NetFabric.Hyperlinq/Quantifier/All/All.Array.cs
@@ -5,11 +5,7 @@ namespace NetFabric.Hyperlinq
     public static partial class Array
     {
         public static bool All<TSource>(this TSource[] source, Func<TSource, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return All<TSource>(source, predicate, 0, source.Length);
-        }
+            => All<TSource>(source, predicate, 0, source.Length);
 
         static bool All<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
@@ -23,11 +19,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static bool All<TSource>(this TSource[] source, Func<TSource, int, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return All<TSource>(source, predicate, 0, source.Length);
-        }
+            => All<TSource>(source, predicate, 0, source.Length);
 
         static bool All<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {

--- a/NetFabric.Hyperlinq/Quantifier/All/All.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Quantifier/All/All.ReadOnlySpan.cs
@@ -6,8 +6,6 @@ namespace NetFabric.Hyperlinq
     {
         public static bool All<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var index = 0;
             var length = source.Length;
             while (index < length && predicate(source[index]))
@@ -19,8 +17,6 @@ namespace NetFabric.Hyperlinq
 
         public static bool All<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var index = 0;
             var length = source.Length;
             while (index < length && predicate(source[index], index))

--- a/NetFabric.Hyperlinq/Quantifier/All/All.Span.cs
+++ b/NetFabric.Hyperlinq/Quantifier/All/All.Span.cs
@@ -6,8 +6,6 @@ namespace NetFabric.Hyperlinq
     {
         public static bool All<TSource>(this Span<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var index = 0;
             var length = source.Length;
             while (index < length && predicate(source[index]))
@@ -19,8 +17,6 @@ namespace NetFabric.Hyperlinq
 
         public static bool All<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var index = 0;
             var length = source.Length;
             while (index < length && predicate(source[index], index))

--- a/NetFabric.Hyperlinq/Quantifier/All/All.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Quantifier/All/All.ValueEnumerable.cs
@@ -9,8 +9,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             using (var enumerator = source.GetEnumerator())
             {
                 while (enumerator.MoveNext())
@@ -26,8 +24,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var index = 0;
             using (var enumerator = source.GetEnumerator())
             {

--- a/NetFabric.Hyperlinq/Quantifier/All/All.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Quantifier/All/All.ValueReadOnlyCollection.cs
@@ -9,8 +9,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             if (source.Count != 0)
             {
                 using (var enumerator = source.GetEnumerator())
@@ -29,8 +27,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             if (source.Count != 0)
             {
                 var index = 0;

--- a/NetFabric.Hyperlinq/Quantifier/All/All.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Quantifier/All/All.ValueReadOnlyList.cs
@@ -8,11 +8,7 @@ namespace NetFabric.Hyperlinq
         public static bool All<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return All<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => All<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static bool All<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
@@ -30,11 +26,7 @@ namespace NetFabric.Hyperlinq
         public static bool All<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return All<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => All<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static bool All<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>

--- a/NetFabric.Hyperlinq/Quantifier/Any/Any.Array.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Any/Any.Array.cs
@@ -11,11 +11,7 @@ namespace NetFabric.Hyperlinq
             => takeCount != 0;
 
         public static bool Any<TSource>(this TSource[] source, Func<TSource, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return Any<TSource>(source, predicate, 0, source.Length);
-        }
+            => Any<TSource>(source, predicate, 0, source.Length);
 
         static bool Any<TSource>(this TSource[] source, Func<TSource, bool> predicate, int skipCount, int takeCount)
         {
@@ -29,11 +25,7 @@ namespace NetFabric.Hyperlinq
         }
 
         public static bool Any<TSource>(this TSource[] source, Func<TSource, int, bool> predicate)
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return Any<TSource>(source, predicate, 0, source.Length);
-        }
+            => Any<TSource>(source, predicate, 0, source.Length);
 
         static bool Any<TSource>(this TSource[] source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
         {

--- a/NetFabric.Hyperlinq/Quantifier/Any/Any.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Any/Any.ReadOnlySpan.cs
@@ -9,8 +9,6 @@ namespace NetFabric.Hyperlinq
 
         public static bool Any<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -22,8 +20,6 @@ namespace NetFabric.Hyperlinq
 
         public static bool Any<TSource>(this ReadOnlySpan<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {

--- a/NetFabric.Hyperlinq/Quantifier/Any/Any.Span.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Any/Any.Span.cs
@@ -9,8 +9,6 @@ namespace NetFabric.Hyperlinq
 
         public static bool Any<TSource>(this Span<TSource> source, Func<TSource, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {
@@ -22,8 +20,6 @@ namespace NetFabric.Hyperlinq
 
         public static bool Any<TSource>(this Span<TSource> source, Func<TSource, long, bool> predicate)
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             var length = source.Length;
             for (var index = 0; index < length; index++)
             {

--- a/NetFabric.Hyperlinq/Quantifier/Any/Any.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Any/Any.ValueEnumerable.cs
@@ -19,8 +19,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             using (var enumerator = source.GetEnumerator())
             {
                 while (enumerator.MoveNext())
@@ -36,8 +34,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             using (var enumerator = source.GetEnumerator())
             {
                 var index = 0;

--- a/NetFabric.Hyperlinq/Quantifier/Any/Any.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Any/Any.ValueReadOnlyCollection.cs
@@ -14,8 +14,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             if (source.Count != 0)
             {
                 using (var enumerator = source.GetEnumerator())
@@ -34,8 +32,6 @@ namespace NetFabric.Hyperlinq
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
             if (source.Count != 0)
             {
                 using (var enumerator = source.GetEnumerator())

--- a/NetFabric.Hyperlinq/Quantifier/Any/Any.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Any/Any.ValueReadOnlyList.cs
@@ -18,11 +18,7 @@ namespace NetFabric.Hyperlinq
         public static bool Any<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return Any<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => Any<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static bool Any<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
@@ -40,11 +36,7 @@ namespace NetFabric.Hyperlinq
         public static bool Any<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
-        {
-            if (predicate is null) ThrowHelper.ThrowArgumentNullException(nameof(predicate));
-
-            return Any<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
-        }
+            => Any<TEnumerable, TEnumerator, TSource>(source, predicate, 0, source.Count);
 
         static bool Any<TEnumerable, TEnumerator, TSource>(this TEnumerable source, Func<TSource, int, bool> predicate, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>

--- a/NetFabric.Hyperlinq/Quantifier/Contains/Contains.Array.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Contains/Contains.Array.cs
@@ -14,7 +14,7 @@ namespace NetFabric.Hyperlinq
         public static bool Contains<TSource>(this TSource[] source, TSource value, IEqualityComparer<TSource> comparer)
             => Contains<TSource>(source, value, comparer, 0, source.Length);
 
-        static bool Contains<TSource>(this TSource[] source, TSource value, IEqualityComparer<TSource> comparer, int skipCount, int takeCount)
+        static bool Contains<TSource>(this TSource[] source, TSource value, IEqualityComparer<TSource>? comparer, int skipCount, int takeCount)
         {
             if (takeCount != 0)
             {

--- a/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ReadOnlySpan.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ReadOnlySpan.cs
@@ -5,7 +5,7 @@ namespace NetFabric.Hyperlinq
 {
     public static partial class ReadOnlySpanExtensions
     {
-        public static bool Contains<TSource>(this ReadOnlySpan<TSource> source, TSource value, IEqualityComparer<TSource> comparer = null)
+        public static bool Contains<TSource>(this ReadOnlySpan<TSource> source, TSource value, IEqualityComparer<TSource>? comparer = null)
         {
             var length = source.Length;
             if (length == 0) return false;

--- a/NetFabric.Hyperlinq/Quantifier/Contains/Contains.Span.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Contains/Contains.Span.cs
@@ -5,7 +5,7 @@ namespace NetFabric.Hyperlinq
 {
     public static partial class SpanExtensions
     {
-        public static bool Contains<TSource>(this Span<TSource> source, TSource value, IEqualityComparer<TSource> comparer = null)
+        public static bool Contains<TSource>(this Span<TSource> source, TSource value, IEqualityComparer<TSource>? comparer = null)
         {
             var length = source.Length;
             if (length == 0) return false;

--- a/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ValueEnumerable.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ValueEnumerable.cs
@@ -5,7 +5,7 @@ namespace NetFabric.Hyperlinq
 {
     public static partial class ValueEnumerable
     {
-        public static bool Contains<TEnumerable, TEnumerator, TSource>(this TEnumerable source, TSource value, IEqualityComparer<TSource> comparer = null)
+        public static bool Contains<TEnumerable, TEnumerator, TSource>(this TEnumerable source, TSource value, IEqualityComparer<TSource>? comparer = null)
             where TEnumerable : IValueEnumerable<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {

--- a/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ValueReadOnlyCollection.cs
@@ -5,7 +5,7 @@ namespace NetFabric.Hyperlinq
 {
     public static partial class ValueReadOnlyCollection
     {
-        public static bool Contains<TEnumerable, TEnumerator, TSource>(this TEnumerable source, TSource value, IEqualityComparer<TSource> comparer = null)
+        public static bool Contains<TEnumerable, TEnumerator, TSource>(this TEnumerable source, TSource value, IEqualityComparer<TSource>? comparer = null)
             where TEnumerable : IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {

--- a/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ValueReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ValueReadOnlyList.cs
@@ -10,7 +10,7 @@ namespace NetFabric.Hyperlinq
             where TEnumerator : struct, IEnumerator<TSource>
             => Contains<TEnumerable, TEnumerator, TSource>(source, value, comparer, 0, source.Count);
 
-        static bool Contains<TEnumerable, TEnumerator, TSource>(this TEnumerable source, TSource value, IEqualityComparer<TSource> comparer, int skipCount, int takeCount)
+        static bool Contains<TEnumerable, TEnumerator, TSource>(this TEnumerable source, TSource value, IEqualityComparer<TSource>? comparer, int skipCount, int takeCount)
             where TEnumerable : IValueReadOnlyList<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {

--- a/NetFabric.Hyperlinq/Utils/ThrowHelper.cs
+++ b/NetFabric.Hyperlinq/Utils/ThrowHelper.cs
@@ -7,12 +7,6 @@ namespace NetFabric.Hyperlinq
         public static void ThrowArgumentException(string message, string paramName)
             => throw new ArgumentException(message, paramName);
 
-        public static void ThrowArgumentNullException(string paramName)
-            => throw new ArgumentNullException(paramName);
-
-        public static T ThrowArgumentNullException<T>(string paramName)
-            => throw new ArgumentNullException(paramName);
-
         public static void ThrowArgumentOutOfRangeException(string paramName)
             => throw new ArgumentOutOfRangeException(paramName);
 


### PR DESCRIPTION
Replace null checks for c# 8 nullable reference types.