### PR TITLE
Set Single() benchmarks to find element in the middle

### DIFF
--- a/NetFabric.Hyperlinq.Benchmarks/Single.Predicate.Benchmarks.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Single.Predicate.Benchmarks.cs
@@ -11,88 +11,91 @@ namespace NetFabric.Hyperlinq.Benchmarks
     [MarkdownExporterAttribute.GitHub]
     public class SinglePredicateBenchmarks : BenchmarksBase
     {
+        [Params(5_000)]
+        public int ItemValue { get; set; }
+
         [BenchmarkCategory("Array")]
         [Benchmark(Baseline = true)]
         public int Linq_Array() =>
-            System.Linq.Enumerable.Single(array, item => item == Count - 1);
+            System.Linq.Enumerable.Single(array, item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Value")]
         [Benchmark(Baseline = true)]
         public int Linq_Enumerable_Value() =>
-            System.Linq.Enumerable.Single(enumerableValue, item => item == Count - 1);
+            System.Linq.Enumerable.Single(enumerableValue, item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Value")]
         [Benchmark(Baseline = true)]
         public int Linq_Collection_Value() =>
-            System.Linq.Enumerable.Single(collectionValue, item => item == Count - 1);
+            System.Linq.Enumerable.Single(collectionValue, item => item == ItemValue);
 
         [BenchmarkCategory("List_Value")]
         [Benchmark(Baseline = true)]
         public int Linq_List_Value() =>
-            System.Linq.Enumerable.Single(listValue, item => item == Count - 1);
+            System.Linq.Enumerable.Single(listValue, item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Reference")]
         [Benchmark(Baseline = true)]
         public int Linq_Enumerable_Reference() =>
-            System.Linq.Enumerable.Single(enumerableReference, item => item == Count - 1);
+            System.Linq.Enumerable.Single(enumerableReference, item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Reference")]
         [Benchmark(Baseline = true)]
         public int Linq_Collection_Reference() =>
-            System.Linq.Enumerable.Single(collectionReference, item => item == Count - 1);
+            System.Linq.Enumerable.Single(collectionReference, item => item == ItemValue);
 
         [BenchmarkCategory("List_Reference")]
         [Benchmark(Baseline = true)]
         public int Linq_List_Reference() =>
-            System.Linq.Enumerable.Single(listReference, item => item == Count - 1);
+            System.Linq.Enumerable.Single(listReference, item => item == ItemValue);
 
         [BenchmarkCategory("Array")]
         [Benchmark]
         public int LinqFaster_Array() =>
-            array.SingleF(item => item == Count - 1);
+            array.SingleF(item => item == ItemValue);
 
         [BenchmarkCategory("Array")]
         [Benchmark]
         public int Hyperlinq_Array() =>
-            array.Single(item => item == Count - 1);
+            array.Single(item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Value")]
         [Benchmark]
         public int Hyperlinq_Enumerable_Value() =>
             Enumerable.AsValueEnumerable<TestEnumerable.Enumerable, TestEnumerable.Enumerable.Enumerator, int>(enumerableValue, enumerable => enumerable.GetEnumerator())
-            .Single(item => item == Count - 1);
+            .Single(item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Value")]
         [Benchmark]
         public int Hyperlinq_Collection_Value() =>
             ReadOnlyCollection.AsValueEnumerable<TestCollection.Enumerable, TestCollection.Enumerable.Enumerator, int>(collectionValue, enumerable => enumerable.GetEnumerator())
-            .Single(item => item == Count - 1);
+            .Single(item => item == ItemValue);
 
         [BenchmarkCategory("List_Value")]
         [Benchmark]
         public int Hyperlinq_List_Value() =>
             ReadOnlyList.AsValueEnumerable<TestList.Enumerable, TestList.Enumerable.Enumerator, int>(listValue, enumerable => enumerable.GetEnumerator())
-            .Single(item => item == Count - 1);
+            .Single(item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Reference")]
         [Benchmark]
         public int Hyperlinq_Enumerable_Reference() =>
             enumerableReference
             .AsValueEnumerable()
-            .Single(item => item == Count - 1);
+            .Single(item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Reference")]
         [Benchmark]
         public int Hyperlinq_Collection_Reference() =>
             collectionReference
             .AsValueEnumerable()
-            .Single(item => item == Count - 1);
+            .Single(item => item == ItemValue);
 
         [BenchmarkCategory("List_Reference")]
         [Benchmark]
         public int Hyperlinq_List_Reference() =>
             listReference
             .AsValueEnumerable()
-            .Single(item => item == Count - 1);
+            .Single(item => item == ItemValue);
     }
 }

--- a/NetFabric.Hyperlinq.Benchmarks/SingleOrDefault.Predicate.Benchmarks.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/SingleOrDefault.Predicate.Benchmarks.cs
@@ -11,88 +11,91 @@ namespace NetFabric.Hyperlinq.Benchmarks
     [MarkdownExporterAttribute.GitHub]
     public class SingleOrDefaultPredicateBenchmarks : BenchmarksBase
     {
+        [Params(5_000)]
+        public int ItemValue { get; set; }
+
         [BenchmarkCategory("Array")]
         [Benchmark(Baseline = true)]
         public int Linq_Array() =>
-            System.Linq.Enumerable.SingleOrDefault(array, item => item == Count - 1);
+            System.Linq.Enumerable.SingleOrDefault(array, item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Value")]
         [Benchmark(Baseline = true)]
         public int Linq_Enumerable_Value() =>
-            System.Linq.Enumerable.SingleOrDefault(enumerableValue, item => item == Count - 1);
+            System.Linq.Enumerable.SingleOrDefault(enumerableValue, item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Value")]
         [Benchmark(Baseline = true)]
         public int Linq_Collection_Value() =>
-            System.Linq.Enumerable.SingleOrDefault(collectionValue, item => item == Count - 1);
+            System.Linq.Enumerable.SingleOrDefault(collectionValue, item => item == ItemValue);
 
         [BenchmarkCategory("List_Value")]
         [Benchmark(Baseline = true)]
         public int Linq_List_Value() =>
-            System.Linq.Enumerable.SingleOrDefault(listValue, item => item == Count - 1);
+            System.Linq.Enumerable.SingleOrDefault(listValue, item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Reference")]
         [Benchmark(Baseline = true)]
         public int Linq_Enumerable_Reference() =>
-            System.Linq.Enumerable.SingleOrDefault(enumerableReference, item => item == Count - 1);
+            System.Linq.Enumerable.SingleOrDefault(enumerableReference, item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Reference")]
         [Benchmark(Baseline = true)]
         public int Linq_Collection_Reference() =>
-            System.Linq.Enumerable.SingleOrDefault(collectionReference, item => item == Count - 1);
+            System.Linq.Enumerable.SingleOrDefault(collectionReference, item => item == ItemValue);
 
         [BenchmarkCategory("List_Reference")]
         [Benchmark(Baseline = true)]
         public int Linq_List_Reference() =>
-            System.Linq.Enumerable.SingleOrDefault(listReference, item => item == Count - 1);
+            System.Linq.Enumerable.SingleOrDefault(listReference, item => item == ItemValue);
 
         [BenchmarkCategory("Array")]
         [Benchmark]
         public int LinqFaster_Array() =>
-            array.SingleOrDefaultF(item => item == Count - 1);
+            array.SingleOrDefaultF(item => item == ItemValue);
 
         [BenchmarkCategory("Array")]
         [Benchmark]
         public int Hyperlinq_Array() =>
-            array.SingleOrDefault(item => item == Count - 1);
+            array.SingleOrDefault(item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Value")]
         [Benchmark]
         public int Hyperlinq_Enumerable_Value() =>
             Enumerable.AsValueEnumerable<TestEnumerable.Enumerable, TestEnumerable.Enumerable.Enumerator, int>(enumerableValue, enumerable => enumerable.GetEnumerator())
-            .SingleOrDefault(item => item == Count - 1);
+            .SingleOrDefault(item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Value")]
         [Benchmark]
         public int Hyperlinq_Collection_Value() =>
             ReadOnlyCollection.AsValueEnumerable<TestCollection.Enumerable, TestCollection.Enumerable.Enumerator, int>(collectionValue, enumerable => enumerable.GetEnumerator())
-            .SingleOrDefault(item => item == Count - 1);
+            .SingleOrDefault(item => item == ItemValue);
 
         [BenchmarkCategory("List_Value")]
         [Benchmark]
         public int Hyperlinq_List_Value() =>
             ReadOnlyList.AsValueEnumerable<TestList.Enumerable, TestList.Enumerable.Enumerator, int>(listValue, enumerable => enumerable.GetEnumerator())
-            .SingleOrDefault(item => item == Count - 1);
+            .SingleOrDefault(item => item == ItemValue);
 
         [BenchmarkCategory("Enumerable_Reference")]
         [Benchmark]
         public int Hyperlinq_Enumerable_Reference() =>
             enumerableReference
             .AsValueEnumerable()
-            .SingleOrDefault(item => item == Count - 1);
+            .SingleOrDefault(item => item == ItemValue);
 
         [BenchmarkCategory("Collection_Reference")]
         [Benchmark]
         public int Hyperlinq_Collection_Reference() =>
             collectionReference
             .AsValueEnumerable()
-            .SingleOrDefault(item => item == Count - 1);
+            .SingleOrDefault(item => item == ItemValue);
 
         [BenchmarkCategory("List_Reference")]
         [Benchmark]
         public int Hyperlinq_List_Reference() =>
             listReference
             .AsValueEnumerable()
-            .SingleOrDefault(item => item == Count - 1);
+            .SingleOrDefault(item => item == ItemValue);
     }
 }


### PR DESCRIPTION
Worst case scenario for `Single(Func<TSource, bool>)` is to get an element from somewhere in the middle.