### PR TITLE
Implement ICollection and IList

### DIFF
--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Bindings.cs
@@ -173,6 +173,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "System.Collections.Generic.KeyValuePair<TKey, TValue>", true)]
         public readonly partial struct ValueWrapper<TKey, TValue>
             : IValueReadOnlyCollection<KeyValuePair<TKey, TValue>, Dictionary<TKey, TValue>.Enumerator>
+            , ICollection<KeyValuePair<TKey, TValue>>
         {
             readonly Dictionary<TKey, TValue> source;
 
@@ -187,6 +188,21 @@ namespace NetFabric.Hyperlinq
             public readonly Dictionary<TKey, TValue>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly  
+                => true;
+
+            void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) 
+                => ((ICollection<KeyValuePair<TKey, TValue>>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item) 
+                => throw new NotImplementedException();
+            void ICollection<KeyValuePair<TKey, TValue>>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item) 
+                => throw new NotImplementedException();
+            bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item) 
+                => throw new NotImplementedException();        
         }
 
         public static int Count<TKey, TValue>(this ValueWrapper<TKey, TValue> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Keys.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Keys.Bindings.cs
@@ -172,6 +172,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "TKey")]
         public readonly partial struct ValueWrapper<TKey, TValue>
             : IValueReadOnlyCollection<TKey, Dictionary<TKey, TValue>.KeyCollection.Enumerator>
+            , ICollection<TKey>
         {
             readonly Dictionary<TKey, TValue>.KeyCollection source;
 
@@ -186,6 +187,21 @@ namespace NetFabric.Hyperlinq
             public readonly Dictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TKey>.IsReadOnly  
+                => true;
+
+            void ICollection<TKey>.CopyTo(TKey[] array, int arrayIndex) 
+                => ((ICollection<TKey>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TKey>.Add(TKey item) 
+                => throw new NotImplementedException();
+            void ICollection<TKey>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TKey>.Contains(TKey item) 
+                => throw new NotImplementedException();
+            bool ICollection<TKey>.Remove(TKey item) 
+                => throw new NotImplementedException();   
         }
 
         public static int Count<TKey, TValue>(this ValueWrapper<TKey, TValue> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Values.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Dictionary.Values.Bindings.cs
@@ -172,6 +172,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "TValue")]
         public readonly partial struct ValueWrapper<TKey, TValue>
             : IValueReadOnlyCollection<TValue, Dictionary<TKey, TValue>.ValueCollection.Enumerator>
+            , ICollection<TValue>
         {
             readonly Dictionary<TKey, TValue>.ValueCollection source;
 
@@ -186,6 +187,21 @@ namespace NetFabric.Hyperlinq
             public readonly Dictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TValue>.IsReadOnly  
+                => true;
+
+            void ICollection<TValue>.CopyTo(TValue[] array, int arrayIndex) 
+                => ((ICollection<TValue>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TValue>.Add(TValue item) 
+                => throw new NotImplementedException();
+            void ICollection<TValue>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TValue>.Contains(TValue item) 
+                => throw new NotImplementedException();
+            bool ICollection<TValue>.Remove(TValue item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TKey, TValue>(this ValueWrapper<TKey, TValue> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/HashSet.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/HashSet.Bindings.cs
@@ -171,6 +171,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyCollection<TSource, HashSet<TSource>.Enumerator>
+            , ICollection<TSource>
         {
             readonly HashSet<TSource> source;
 
@@ -185,6 +186,21 @@ namespace NetFabric.Hyperlinq
             public readonly HashSet<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => ((ICollection<TSource>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TSource>(this ValueWrapper<TSource> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/LinkedList.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/LinkedList.Bindings.cs
@@ -171,6 +171,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyCollection<TSource, LinkedList<TSource>.Enumerator>
+            , ICollection<TSource>
         {
             readonly LinkedList<TSource> source;
 
@@ -185,6 +186,21 @@ namespace NetFabric.Hyperlinq
             public readonly LinkedList<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => ((ICollection<TSource>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TSource>(this ValueWrapper<TSource> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/List.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/List.Bindings.cs
@@ -170,6 +170,7 @@ namespace NetFabric.Hyperlinq
         
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyList<TSource, List<TSource>.Enumerator>
+            , IList<TSource>
         {
             readonly List<TSource> source;
 
@@ -180,14 +181,40 @@ namespace NetFabric.Hyperlinq
                 => source.Count;
 
             [MaybeNull]
-            public readonly TSource this[int index]
-                => source[index];
+            public readonly TSource this[int index] => source[index];
 
             [Pure]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly List<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => source[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => source.CopyTo(array, arrayIndex);
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => source.Contains(item);
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+                => source.IndexOf(item);
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
         }    
     }
 }

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Queue.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Queue.Bindings.cs
@@ -171,6 +171,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyCollection<TSource, Queue<TSource>.Enumerator>
+            , ICollection<TSource>
         {
             readonly Queue<TSource> source;
 
@@ -185,6 +186,21 @@ namespace NetFabric.Hyperlinq
             public readonly Queue<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => ((ICollection<TSource>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TSource>(this ValueWrapper<TSource> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Bindings.cs
@@ -173,6 +173,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "System.Collections.Generic.KeyValuePair<TKey, TValue>", true)]
         public readonly partial struct ValueWrapper<TKey, TValue>
             : IValueReadOnlyCollection<KeyValuePair<TKey, TValue>, SortedDictionary<TKey, TValue>.Enumerator>
+            , ICollection<KeyValuePair<TKey, TValue>>
         {
             readonly SortedDictionary<TKey, TValue> source;
 
@@ -187,6 +188,21 @@ namespace NetFabric.Hyperlinq
             public readonly SortedDictionary<TKey, TValue>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly  
+                => true;
+
+            void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) 
+                => ((ICollection<KeyValuePair<TKey, TValue>>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item) 
+                => throw new NotImplementedException();
+            void ICollection<KeyValuePair<TKey, TValue>>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item) 
+                => throw new NotImplementedException();
+            bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item) 
+                => throw new NotImplementedException();             
         }
 
         public static int Count<TKey, TValue>(this ValueWrapper<TKey, TValue> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Keys.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Keys.Bindings.cs
@@ -172,6 +172,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "TKey")]
         public readonly partial struct ValueWrapper<TKey, TValue>
             : IValueReadOnlyCollection<TKey, SortedDictionary<TKey, TValue>.KeyCollection.Enumerator>
+            , ICollection<TKey>
         {
             readonly SortedDictionary<TKey, TValue>.KeyCollection source;
 
@@ -186,6 +187,21 @@ namespace NetFabric.Hyperlinq
             public readonly SortedDictionary<TKey, TValue>.KeyCollection.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TKey>.IsReadOnly  
+                => true;
+
+            void ICollection<TKey>.CopyTo(TKey[] array, int arrayIndex) 
+                => ((ICollection<TKey>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TKey>.Add(TKey item) 
+                => throw new NotImplementedException();
+            void ICollection<TKey>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TKey>.Contains(TKey item) 
+                => throw new NotImplementedException();
+            bool ICollection<TKey>.Remove(TKey item) 
+                => throw new NotImplementedException();   
         }
 
         public static int Count<TKey, TValue>(this ValueWrapper<TKey, TValue> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Values.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedDictionary.Values.Bindings.cs
@@ -172,6 +172,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "TValue")]
         public readonly partial struct ValueWrapper<TKey, TValue>
             : IValueReadOnlyCollection<TValue, SortedDictionary<TKey, TValue>.ValueCollection.Enumerator>
+            , ICollection<TValue>
         {
             readonly SortedDictionary<TKey, TValue>.ValueCollection source;
 
@@ -186,6 +187,21 @@ namespace NetFabric.Hyperlinq
             public readonly SortedDictionary<TKey, TValue>.ValueCollection.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TValue>.IsReadOnly  
+                => true;
+
+            void ICollection<TValue>.CopyTo(TValue[] array, int arrayIndex) 
+                => ((ICollection<TValue>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TValue>.Add(TValue item) 
+                => throw new NotImplementedException();
+            void ICollection<TValue>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TValue>.Contains(TValue item) 
+                => throw new NotImplementedException();
+            bool ICollection<TValue>.Remove(TValue item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TKey, TValue>(this ValueWrapper<TKey, TValue> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedSet.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/SortedSet.Bindings.cs
@@ -171,6 +171,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyCollection<TSource, SortedSet<TSource>.Enumerator>
+            , ICollection<TSource>
         {
             readonly SortedSet<TSource> source;
 
@@ -185,6 +186,21 @@ namespace NetFabric.Hyperlinq
             public readonly SortedSet<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => ((ICollection<TSource>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TSource>(this ValueWrapper<TSource> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Stack.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Generic/Stack.Bindings.cs
@@ -171,6 +171,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyCollection<TSource, Stack<TSource>.Enumerator>
+            , ICollection<TSource>
         {
             readonly Stack<TSource> source;
 
@@ -185,6 +186,21 @@ namespace NetFabric.Hyperlinq
             public readonly Stack<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             readonly IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => ((ICollection<TSource>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TSource>(this ValueWrapper<TSource> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Immutable/ImmutableArray.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Immutable/ImmutableArray.Bindings.cs
@@ -112,6 +112,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyList<TSource, ValueWrapper<TSource>.Enumerator>
+            , IList<TSource>
         {
             readonly ImmutableArray<TSource> source;
 
@@ -129,6 +130,33 @@ namespace NetFabric.Hyperlinq
             public readonly Enumerator GetEnumerator() => new Enumerator(source);
             IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new Enumerator(source);
             IEnumerator IEnumerable.GetEnumerator() => new Enumerator(source);
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => source[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => source.CopyTo(array, arrayIndex);
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => source.Contains(item);
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+                => source.IndexOf(item);
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
                 : IEnumerator<TSource>

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Immutable/ImmutableHashSet.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Immutable/ImmutableHashSet.Bindings.cs
@@ -172,6 +172,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyCollection<TSource, ImmutableHashSet<TSource>.Enumerator>
+            , ICollection<TSource>
         {
             readonly ImmutableHashSet<TSource> source;
 
@@ -185,6 +186,21 @@ namespace NetFabric.Hyperlinq
             public readonly ImmutableHashSet<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => ((ICollection<TSource>)source).CopyTo(array, arrayIndex);
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
         }
 
         public static int Count<TSource>(this ValueWrapper<TSource> source)

--- a/NetFabric.Hyperlinq/Bindings/System/Collections/Immutable/ImmutableList.Bindings.cs
+++ b/NetFabric.Hyperlinq/Bindings/System/Collections/Immutable/ImmutableList.Bindings.cs
@@ -172,6 +172,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueWrapper<TSource>
             : IValueReadOnlyList<TSource, ImmutableList<TSource>.Enumerator>
+            , IList<TSource>
         {
             readonly ImmutableList<TSource> source;
 
@@ -189,6 +190,33 @@ namespace NetFabric.Hyperlinq
             public readonly ImmutableList<TSource>.Enumerator GetEnumerator() => source.GetEnumerator();
             IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => source.GetEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => source.GetEnumerator();
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => source[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => source.CopyTo(array, arrayIndex);
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => source.Contains(item);
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+                => source.IndexOf(item);
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
         }
 
         public static int Count<TSource>(this ValueWrapper<TSource> source)

--- a/NetFabric.Hyperlinq/Conversion/AsValueEnumerable/AsValueEnumerable.Array.cs
+++ b/NetFabric.Hyperlinq/Conversion/AsValueEnumerable/AsValueEnumerable.Array.cs
@@ -16,11 +16,18 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ArrayValueEnumerableWrapper<TSource>
             : IValueReadOnlyList<TSource, ArrayValueEnumerableWrapper<TSource>.DisposableEnumerator>
+            , IList<TSource>
         {
             readonly TSource[] source;
 
             internal ArrayValueEnumerableWrapper(TSource[] source) 
                 => this.source = source;
+
+            public readonly int Count => source.Length;
+
+            [MaybeNull]
+            public readonly ref readonly TSource this[int index] 
+                => ref source[index];
 
             [Pure]
             public readonly Enumerator GetEnumerator() 
@@ -32,14 +39,43 @@ namespace NetFabric.Hyperlinq
             readonly IEnumerator IEnumerable.GetEnumerator() 
                 => new DisposableEnumerator(source);
 
-            public readonly int Count => source.Length;
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => source[index];
+                set => throw new NotImplementedException();
+            }
 
             [MaybeNull]
-            public readonly ref readonly TSource this[int index] 
-                => ref source[index];
-            [MaybeNull]
-            readonly TSource IReadOnlyList<TSource>.this[int index] 
+            TSource IReadOnlyList<TSource>.this[int index]
                 => source[index];
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => source.CopyTo(array, arrayIndex);
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => source.Contains(item);
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+            {
+                for (var index = 0; index < source.Length; index++)
+                {
+                    if (EqualityComparer<TSource>.Default.Equals(source[index], item))
+                        return index;
+                }
+                return -1;
+            }
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
             {

--- a/NetFabric.Hyperlinq/Conversion/AsValueEnumerable/AsValueEnumerable.ReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Conversion/AsValueEnumerable/AsValueEnumerable.ReadOnlyCollection.cs
@@ -24,6 +24,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueEnumerableWrapper<TEnumerable, TEnumerator, TSource>
             : IValueReadOnlyCollection<TSource, TEnumerator>
+            , ICollection<TSource>
             where TEnumerable : notnull, IReadOnlyCollection<TSource>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -48,6 +49,31 @@ namespace NetFabric.Hyperlinq
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => getEnumerator(source);
             readonly IEnumerator IEnumerable.GetEnumerator() => getEnumerator(source);
 
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            {
+                if (source.Count == 0)
+                    return;
+
+                checked
+                {
+                    using var enumerator = source.GetEnumerator();
+                    for (var index = arrayIndex; enumerator.MoveNext(); index++)
+                        array[index] = enumerator.Current;
+                }
+            }
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+
             [Pure]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public TSource[] ToArray()
@@ -61,6 +87,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueEnumerableWrapper<TSource>
             : IValueReadOnlyCollection<TSource, ValueEnumerableWrapper<TSource>.Enumerator>
+            , ICollection<TSource>
         {
             readonly IReadOnlyCollection<TSource> source;
 
@@ -75,6 +102,31 @@ namespace NetFabric.Hyperlinq
             public readonly Enumerator GetEnumerator() => new Enumerator(source);
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new Enumerator(source);
             readonly IEnumerator IEnumerable.GetEnumerator() => new Enumerator(source);
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            {
+                if (source.Count == 0)
+                    return;
+
+                checked
+                {
+                    using var enumerator = source.GetEnumerator();
+                    for (var index = arrayIndex; enumerator.MoveNext(); index++)
+                        array[index] = enumerator.Current;
+                }
+            }
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
 
             public readonly struct Enumerator
                 : IEnumerator<TSource>

--- a/NetFabric.Hyperlinq/Conversion/AsValueEnumerable/AsValueEnumerable.ReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Conversion/AsValueEnumerable/AsValueEnumerable.ReadOnlyList.cs
@@ -16,6 +16,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ValueEnumerableWrapper<TSource>
             : IValueReadOnlyList<TSource, ValueEnumerableWrapper<TSource>.Enumerator>
+            , IList<TSource>
         {
             readonly IReadOnlyList<TSource> source;
 
@@ -34,6 +35,49 @@ namespace NetFabric.Hyperlinq
             public readonly Enumerator GetEnumerator() => new Enumerator(source);
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new Enumerator(source);
             readonly IEnumerator IEnumerable.GetEnumerator() => new Enumerator(source);
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => source[index];
+                set => throw new NotImplementedException();
+            }
+
+            [MaybeNull]
+            TSource IReadOnlyList<TSource>.this[int index]
+                => source[index];
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            {
+                for (var index = 0; index < source.Count; index++)
+                    array[arrayIndex + index] = source[index];
+            }
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => source.Contains(item);
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+            {
+                for (var index = 0; index < source.Count; index++)
+                {
+                    if (EqualityComparer<TSource>.Default.Equals(source[index], item))
+                        return index;
+                }
+                return -1;
+            }
+
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
                 : IEnumerator<TSource>

--- a/NetFabric.Hyperlinq/Generation/Empty.cs
+++ b/NetFabric.Hyperlinq/Generation/Empty.cs
@@ -15,10 +15,17 @@ namespace NetFabric.Hyperlinq
 
         public partial class EmptyEnumerable<TSource>
             : IValueReadOnlyList<TSource, EmptyEnumerable<TSource>.DisposableEnumerator>
+            , IList<TSource>
         {
             public static readonly EmptyEnumerable<TSource> Instance = new EmptyEnumerable<TSource>();
 
             private EmptyEnumerable() { }
+
+            public int Count 
+                => 0;
+
+            public TSource this[int index] 
+                => Throw.IndexOutOfRangeException<TSource>(); 
 
             [Pure]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -27,11 +34,32 @@ namespace NetFabric.Hyperlinq
             IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new DisposableEnumerator();
             IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator();
 
-            public int Count 
-                => 0;
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
 
-            public TSource this[int index] 
-                => Throw.IndexOutOfRangeException<TSource>(); 
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            { }
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => false;
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+                => -1;
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public readonly struct Enumerator
             {

--- a/NetFabric.Hyperlinq/Generation/Range.cs
+++ b/NetFabric.Hyperlinq/Generation/Range.cs
@@ -30,6 +30,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "int", true)]
         public readonly partial struct RangeEnumerable
             : IValueReadOnlyList<int, RangeEnumerable.DisposableEnumerator>
+            , IList<int>
         {
             readonly int start;
             readonly int count;
@@ -42,13 +43,6 @@ namespace NetFabric.Hyperlinq
                 this.end = end;
             }
 
-            [Pure]
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
-            readonly DisposableEnumerator IValueEnumerable<int, DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator<int> IEnumerable<int>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
-
             public readonly int Count => count;
 
             public readonly int this[int index]
@@ -60,6 +54,43 @@ namespace NetFabric.Hyperlinq
                     return index + start;
                 }
             }
+
+            [Pure]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
+            readonly DisposableEnumerator IValueEnumerable<int, DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator<int> IEnumerable<int>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
+
+            [MaybeNull]
+            int IList<int>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<int>.IsReadOnly  
+                => true;
+
+            void ICollection<int>.CopyTo(int[] array, int arrayIndex) 
+            {
+                for (var index = 0; index < count; index++)
+                    array[arrayIndex + index] = index;
+            }
+            void ICollection<int>.Add(int item) 
+                => throw new NotImplementedException();
+            void ICollection<int>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<int>.Remove(int item) 
+                => throw new NotImplementedException();
+            int IList<int>.IndexOf(int item)
+                => item >= 0 && item < count
+                ? item
+                : -1;
+            void IList<int>.Insert(int index, int item)
+                => throw new NotImplementedException();
+            void IList<int>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
             {

--- a/NetFabric.Hyperlinq/Generation/Repeat.cs
+++ b/NetFabric.Hyperlinq/Generation/Repeat.cs
@@ -19,6 +19,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct RepeatEnumerable<TSource>
             : IValueReadOnlyList<TSource, RepeatEnumerable<TSource>.DisposableEnumerator>
+            , IList<TSource>
         {
             internal readonly TSource value;
             internal readonly int count;
@@ -28,13 +29,6 @@ namespace NetFabric.Hyperlinq
                 this.value = value;
                 this.count = count;
             }
-
-            [Pure]
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
-            readonly DisposableEnumerator IValueEnumerable<TSource, DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
 
             public readonly int Count => count;
 
@@ -48,6 +42,44 @@ namespace NetFabric.Hyperlinq
                     return value;
                 }
             }
+
+            [Pure]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
+            readonly DisposableEnumerator IValueEnumerable<TSource, DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            {
+                var end = arrayIndex + count;
+                for (var index = arrayIndex; index < end; index++)
+                    array[index] = value;
+            }
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+                => count > 0 && EqualityComparer<TSource>.Default.Equals(value, item)
+                ? 0
+                : -1;
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
             {

--- a/NetFabric.Hyperlinq/Generation/Return.cs
+++ b/NetFabric.Hyperlinq/Generation/Return.cs
@@ -15,6 +15,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct ReturnEnumerable<TSource>
             : IValueReadOnlyList<TSource, ReturnEnumerable<TSource>.DisposableEnumerator>
+            , IList<TSource>
         {
             internal readonly TSource value;
 
@@ -22,13 +23,6 @@ namespace NetFabric.Hyperlinq
             {
                 this.value = value;
             }
-
-            [Pure]
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
-            readonly DisposableEnumerator IValueEnumerable<TSource, DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
 
             public readonly int Count => 1;
 
@@ -42,6 +36,40 @@ namespace NetFabric.Hyperlinq
                     return value;
                 }
             }
+
+            [Pure]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
+            readonly DisposableEnumerator IValueEnumerable<TSource, DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+                => array[arrayIndex] = value;
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+                => EqualityComparer<TSource>.Default.Equals(value, item)
+                ? 0
+                : -1;
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
             {

--- a/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.Array.cs
+++ b/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.Array.cs
@@ -16,6 +16,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct SkipTakeEnumerable<TSource>
             : IValueReadOnlyList<TSource, SkipTakeEnumerable<TSource>.Enumerator>
+            , IList<TSource>
         {
             internal readonly TSource[] source;
             internal readonly int skipCount;
@@ -47,6 +48,44 @@ namespace NetFabric.Hyperlinq
             public readonly Enumerator GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator IEnumerable.GetEnumerator() => new Enumerator(in this);
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            {
+                for (var index = 0; index < takeCount; index++)
+                    array[index + arrayIndex] = source[index + skipCount];
+            }
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => Array.Contains<TSource>(source, item, null, skipCount, takeCount);
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+            {
+                var end = skipCount + takeCount;
+                for (var index = skipCount; index < end; index++)
+                {
+                    if (EqualityComparer<TSource>.Default.Equals(source[index], item))
+                        return index;
+                }
+                return -1;
+            }
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
                 : IEnumerator<TSource>

--- a/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.ReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.ReadOnlyList.cs
@@ -17,6 +17,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct SkipTakeEnumerable<TList, TSource>
             : IValueReadOnlyList<TSource, SkipTakeEnumerable<TList, TSource>.Enumerator>
+            , IList<TSource>
             where TList : notnull, IReadOnlyList<TSource>
         {
             internal readonly TList source;
@@ -49,6 +50,44 @@ namespace NetFabric.Hyperlinq
             public readonly Enumerator GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator IEnumerable.GetEnumerator() => new Enumerator(in this);
+
+            [MaybeNull]
+            TSource IList<TSource>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            {
+                for (var index = 0; index < takeCount; index++)
+                    array[index + arrayIndex] = source[index + skipCount];
+            }
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => ReadOnlyList.Contains<TList, TSource>(source, item, null, skipCount, takeCount);
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
+            int IList<TSource>.IndexOf(TSource item)
+            {
+                var end = skipCount + takeCount;
+                for (var index = skipCount; index < end; index++)
+                {
+                    if (EqualityComparer<TSource>.Default.Equals(source[index], item))
+                        return index;
+                }
+                return -1;
+            }
+            void IList<TSource>.Insert(int index, TSource item)
+                => throw new NotImplementedException();
+            void IList<TSource>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
                 : IEnumerator<TSource>

--- a/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Partitioning/SkipTake/SkipTake.ValueReadOnlyCollection.cs
@@ -18,6 +18,7 @@ namespace NetFabric.Hyperlinq
 
         public readonly partial struct SkipTakeEnumerable<TEnumerable, TEnumerator, TSource>
             : IValueReadOnlyCollection<TSource, SkipTakeEnumerable<TEnumerable, TEnumerator, TSource>.Enumerator>
+            , ICollection<TSource>
             where TEnumerable : notnull, IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -38,6 +39,41 @@ namespace NetFabric.Hyperlinq
             public readonly Enumerator GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator<TSource> IEnumerable<TSource>.GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator IEnumerable.GetEnumerator() => new Enumerator(in this);
+
+            bool ICollection<TSource>.IsReadOnly  
+                => true;
+
+            void ICollection<TSource>.CopyTo(TSource[] array, int arrayIndex) 
+            {
+                if (takeCount == 0)
+                    return;
+
+                using var enumerator = source.GetEnumerator();
+
+                // skip
+                for (var counter = 0; counter < skipCount; counter++)
+                {
+                    if (!enumerator.MoveNext()) Throw.InvalidOperationException();
+                }
+
+                // take
+                for (var counter = 0; counter < takeCount; counter++)
+                {
+                    if (!enumerator.MoveNext()) Throw.InvalidOperationException();
+
+                    array[arrayIndex] = enumerator.Current;
+                    arrayIndex++;
+                }
+            }
+
+            void ICollection<TSource>.Add(TSource item) 
+                => throw new NotImplementedException();
+            void ICollection<TSource>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Contains(TSource item) 
+                => throw new NotImplementedException();
+            bool ICollection<TSource>.Remove(TSource item) 
+                => throw new NotImplementedException();
 
             public struct Enumerator
                 : IEnumerator<TSource>

--- a/NetFabric.Hyperlinq/Projection/Select/Select.ReadOnlyMemory.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.ReadOnlyMemory.cs
@@ -22,6 +22,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "TResult")]
         public readonly partial struct MemorySelectEnumerable<TSource, TResult>
             : IValueReadOnlyList<TResult, MemorySelectEnumerable<TSource, TResult>.DisposableEnumerator>
+            , IList<TResult>
         {
             internal readonly ReadOnlyMemory<TSource> source;
             internal readonly Selector<TSource, TResult> selector;
@@ -31,16 +32,6 @@ namespace NetFabric.Hyperlinq
                 this.source = source;
                 this.selector = selector;
             }
-
-            [Pure]
-            public readonly Enumerator GetEnumerator() 
-                => new Enumerator(in this);
-            readonly DisposableEnumerator IValueEnumerable<TResult, MemorySelectEnumerable<TSource, TResult>.DisposableEnumerator>.GetEnumerator() 
-                => new DisposableEnumerator(in this);
-            readonly IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() 
-                => new DisposableEnumerator(in this);
-            readonly IEnumerator IEnumerable.GetEnumerator() 
-                => new DisposableEnumerator(in this);
 
             public readonly int Count => source.Length;
 
@@ -55,6 +46,63 @@ namespace NetFabric.Hyperlinq
                     return selector(source.Span[index]);
                 }
             }
+
+            [Pure]
+            public readonly Enumerator GetEnumerator() 
+                => new Enumerator(in this);
+            readonly DisposableEnumerator IValueEnumerable<TResult, MemorySelectEnumerable<TSource, TResult>.DisposableEnumerator>.GetEnumerator() 
+                => new DisposableEnumerator(in this);
+            readonly IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() 
+                => new DisposableEnumerator(in this);
+            readonly IEnumerator IEnumerable.GetEnumerator() 
+                => new DisposableEnumerator(in this);
+
+            [MaybeNull]
+            TResult IList<TResult>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TResult>.IsReadOnly  
+                => true;
+
+            void ICollection<TResult>.CopyTo(TResult[] array, int arrayIndex) 
+            {
+                var span = source.Span;
+                for (var index = 0; index < source.Length; index++)
+                    array[index + arrayIndex] = selector(span[index]);
+            }
+            void ICollection<TResult>.Add(TResult item) 
+                => throw new NotImplementedException();
+            void ICollection<TResult>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TResult>.Contains(TResult item) 
+            {
+                var span = source.Span;
+                for (var index = 0; index < source.Length; index++)
+                {
+                    if (EqualityComparer<TResult>.Default.Equals(selector(span[index]), item))
+                        return true;
+                }
+                return false;
+            }
+            bool ICollection<TResult>.Remove(TResult item) 
+                => throw new NotImplementedException();
+            int IList<TResult>.IndexOf(TResult item)
+            {
+                var span = source.Span;
+                for (var index = 0; index < source.Length; index++)
+                {
+                    if (EqualityComparer<TResult>.Default.Equals(selector(span[index]), item))
+                        return index;
+                }
+                return -1;
+            }
+            void IList<TResult>.Insert(int index, TResult item)
+                => throw new NotImplementedException();
+            void IList<TResult>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public ref struct Enumerator
             {

--- a/NetFabric.Hyperlinq/Projection/Select/Select.ValueReadOnlyCollection.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.ValueReadOnlyCollection.cs
@@ -24,6 +24,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "TResult")]
         public readonly partial struct SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>
             : IValueReadOnlyCollection<TResult, SelectEnumerable<TEnumerable, TEnumerator, TSource, TResult>.Enumerator>
+            , ICollection<TResult>
             where TEnumerable : notnull, IValueReadOnlyCollection<TSource, TEnumerator>
             where TEnumerator : struct, IEnumerator<TSource>
         {
@@ -36,13 +37,38 @@ namespace NetFabric.Hyperlinq
                 this.selector = selector;
             }
 
+            public readonly int Count => source.Count;
+
             [Pure]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly Enumerator GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() => new Enumerator(in this);
             readonly IEnumerator IEnumerable.GetEnumerator() => new Enumerator(in this);
 
-            public readonly int Count => source.Count;
+            bool ICollection<TResult>.IsReadOnly  
+                => true;
+
+            void ICollection<TResult>.CopyTo(TResult[] array, int arrayIndex) 
+            {
+                if (source.Count == 0)
+                    return;
+
+                checked
+                {
+                    using var enumerator = source.GetEnumerator();
+                    for (var index = arrayIndex; enumerator.MoveNext(); index++)
+                        array[index] = selector(enumerator.Current);
+                }
+            }
+
+            void ICollection<TResult>.Add(TResult item) 
+                => throw new NotImplementedException();
+            void ICollection<TResult>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TResult>.Contains(TResult item) 
+                => throw new NotImplementedException();
+            bool ICollection<TResult>.Remove(TResult item) 
+                => throw new NotImplementedException();
 
             public struct Enumerator
                 : IEnumerator<TResult>

--- a/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ReadOnlyList.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectIndex/SelectIndex.ReadOnlyList.cs
@@ -31,6 +31,7 @@ namespace NetFabric.Hyperlinq
         [GeneratorMapping("TSource", "TResult")]
         public readonly partial struct SelectIndexEnumerable<TList, TSource, TResult>
             : IValueReadOnlyList<TResult, SelectIndexEnumerable<TList, TSource, TResult>.DisposableEnumerator>
+            , IList<TResult>
             where TList : notnull, IReadOnlyList<TSource>
         {
             readonly TList source;
@@ -45,13 +46,6 @@ namespace NetFabric.Hyperlinq
                 (this.skipCount, this.takeCount) = Utils.SkipTake(source.Count, skipCount, takeCount);
             }
 
-            [Pure]
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
-            readonly DisposableEnumerator IValueEnumerable<TResult, SelectIndexEnumerable<TList, TSource, TResult>.DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() => new DisposableEnumerator(in this);
-            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
-
             public readonly int Count => takeCount;
 
             [MaybeNull]
@@ -65,6 +59,57 @@ namespace NetFabric.Hyperlinq
                     return selector(source[index + skipCount], index);
                 }
             }
+
+            [Pure]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public readonly Enumerator GetEnumerator() => new Enumerator(in this);
+            readonly DisposableEnumerator IValueEnumerable<TResult, SelectIndexEnumerable<TList, TSource, TResult>.DisposableEnumerator>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator<TResult> IEnumerable<TResult>.GetEnumerator() => new DisposableEnumerator(in this);
+            readonly IEnumerator IEnumerable.GetEnumerator() => new DisposableEnumerator(in this);
+
+            [MaybeNull]
+            TResult IList<TResult>.this[int index]
+            {
+                get => this[index];
+                set => throw new NotImplementedException();
+            }
+
+            bool ICollection<TResult>.IsReadOnly  
+                => true;
+
+            void ICollection<TResult>.CopyTo(TResult[] array, int arrayIndex) 
+            {
+                for (var index = 0; index < takeCount; index++)
+                    array[index + arrayIndex] = selector(source[index + skipCount], index);
+            }
+            void ICollection<TResult>.Add(TResult item) 
+                => throw new NotImplementedException();
+            void ICollection<TResult>.Clear() 
+                => throw new NotImplementedException();
+            bool ICollection<TResult>.Contains(TResult item) 
+            {
+                for (var index = 0; index < takeCount; index++)
+                {
+                    if (EqualityComparer<TResult>.Default.Equals(selector(source[index + skipCount], index), item))
+                        return true;
+                }
+                return false;
+            }
+            bool ICollection<TResult>.Remove(TResult item) 
+                => throw new NotImplementedException();
+            int IList<TResult>.IndexOf(TResult item)
+            {
+                for (var index = 0; index < takeCount; index++)
+                {
+                    if (EqualityComparer<TResult>.Default.Equals(selector(source[index + skipCount], index), item))
+                        return index;
+                }
+                return -1;
+            }
+            void IList<TResult>.Insert(int index, TResult item)
+                => throw new NotImplementedException();
+            void IList<TResult>.RemoveAt(int index)
+                => throw new NotImplementedException();
 
             public struct Enumerator
             {


### PR DESCRIPTION
Enumerables that implement `IReadOnlyCollection` or `IReadOnlyList` should also implement  `ICollection` or `IList` respectively, with the `IsReadOnly` property returning `true`. This improves compatibility with other libraries like LINQ that make use of these interfaces.