### PR TITLE
Use foreach for full iteration of arrays

### DIFF
--- a/NetFabric.Hyperlinq/Aggregation/Count/Count.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Aggregation/Count/Count.ArraySegment.cs
@@ -18,10 +18,9 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        var result = predicate(array![index]);
+                        var result = predicate(item);
                         counter += *(int*)&result;
                     }
                 }
@@ -46,11 +45,12 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    var index = 0;
+                    foreach (var item in source.Array)
                     {
-                        var result = predicate(array![index], index);
+                        var result = predicate(item, index);
                         counter += *(int*)&result;
+                        index++;
                     }
                 }
                 else

--- a/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Conversion/ToDictionary/ToDictionary.ArraySegment.cs
@@ -17,12 +17,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
-                    {
-                        var item = array![index];
+                    foreach (var item in source.Array)
                         dictionary.Add(keySelector(item), item);
-                    }
                 }
                 else
                 {
@@ -48,12 +44,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
-                    {
-                        var item = array![index];
+                    foreach (var item in source.Array)
                         dictionary.Add(keySelector(item), elementSelector(item)!);
-                    }
                 }
                 else
                 {

--- a/NetFabric.Hyperlinq/Element/ElementAt/ElementAt.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Element/ElementAt/ElementAt.ArraySegment.cs
@@ -17,10 +17,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var sourceIndex = 0; sourceIndex < array.Length; sourceIndex++)
+                    foreach (var item in source.Array)
                     {
-                        var item = array![sourceIndex];
                         if (predicate(item) && index-- == 0)
                             return Option.Some(item);
                     }
@@ -47,12 +45,13 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var sourceIndex = 0; sourceIndex < array.Length; sourceIndex++)
+                    var sourceIndex = 0;
+                    foreach (var item in source.Array)
                     {
-                        var item = array![sourceIndex];
                         if (predicate(item, sourceIndex) && index-- == 0)
                             return Option.Some(item);
+
+                        sourceIndex++;
                     }
                 }
                 else
@@ -106,10 +105,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var sourceIndex = 0; sourceIndex < array.Length; sourceIndex++)
+                    foreach (var item in source.Array)
                     {
-                        var item = array![sourceIndex];
                         if (predicate(item) && index-- == 0)
                             return Option.Some(selector(item));
                     }

--- a/NetFabric.Hyperlinq/Element/First/First.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Element/First/First.ArraySegment.cs
@@ -18,10 +18,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        var item = array![index];
                         if (predicate(item))
                             return Option.Some(item);
                     }
@@ -47,12 +45,13 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    var index = 0;
+                    foreach (var item in source.Array)
                     {
-                        var item = array![index];
                         if (predicate(item, index))
                             return Option.Some(item);
+
+                        index++;
                     }
                 }
                 else
@@ -106,10 +105,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        var item = array![index];
                         if (predicate(item))
                             return Option.Some(selector(item));
                     }

--- a/NetFabric.Hyperlinq/Projection/Select/Select.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Projection/Select/Select.ArraySegment.cs
@@ -87,11 +87,13 @@ namespace NetFabric.Hyperlinq
                     {
                         if (Utils.IsValueType<TResult>())
                         {
-                            var array = source.Array;
-                            for (var index = 0; index < array.Length; index++)
+                            var index = 0;
+                            foreach (var sourceItem in source.Array)
                             {
-                                if (EqualityComparer<TResult>.Default.Equals(selector(array![index])!, item))
+                                if (EqualityComparer<TResult>.Default.Equals(selector(sourceItem)!, item))
                                     return index;
+
+                                index++;
                             }
                         }
                         else

--- a/NetFabric.Hyperlinq/Projection/SelectAt/SelectAt.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Projection/SelectAt/SelectAt.ArraySegment.cs
@@ -88,10 +88,10 @@ namespace NetFabric.Hyperlinq
                     {
                         if (Utils.IsValueType<TResult>())
                         {
-                            var array = source.Array;
-                            for (var index = 0; index < array.Length; index++)
+                            var index = 0;
+                            foreach (var sourceItem in source.Array)
                             {
-                                if (EqualityComparer<TResult>.Default.Equals(selector(array![index], index)!, item))
+                                if (EqualityComparer<TResult>.Default.Equals(selector(sourceItem, index)!, item))
                                     return index;
                             }
                         }

--- a/NetFabric.Hyperlinq/Quantifier/All/All.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Quantifier/All/All.ArraySegment.cs
@@ -15,10 +15,9 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        if (!predicate(array![index]))
+                        if (!predicate(item))
                             return false;
                     }
                 }
@@ -47,11 +46,13 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    var index = 0;
+                    foreach (var item in source.Array)
                     {
-                        if (!predicate(array![index], index))
+                        if (!predicate(item, index))
                             return false;
+
+                        index++;
                     }
                 }
                 else

--- a/NetFabric.Hyperlinq/Quantifier/Any/Any.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Any/Any.ArraySegment.cs
@@ -20,10 +20,9 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        if (predicate(array![index]))
+                        if (predicate(item))
                             return true;
                     }
                 }
@@ -51,11 +50,13 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    var index = 0;
+                    foreach (var item in source.Array)
                     {
-                        if (predicate(array![index], index))
+                        if (predicate(item, index))
                             return true;
+
+                        index++;
                     }
                 }
                 else

--- a/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Quantifier/Contains/Contains.ArraySegment.cs
@@ -13,10 +13,9 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        if (EqualityComparer<TSource>.Default.Equals(array![index], value!))
+                        if (EqualityComparer<TSource>.Default.Equals(item, value!))
                             return true;
                     }
                 }
@@ -51,10 +50,9 @@ namespace NetFabric.Hyperlinq
                 {
                     if (source.IsWhole())
                     {
-                        var array = source.Array;
-                        for (var index = 0; index < array.Length; index++)
+                        foreach (var item in source.Array)
                         {
-                            if (EqualityComparer<TSource>.Default.Equals(array![index], value!))
+                            if (EqualityComparer<TSource>.Default.Equals(item, value!))
                                 return true;
                         }
                     }
@@ -78,10 +76,9 @@ namespace NetFabric.Hyperlinq
                 {
                     if (source.IsWhole())
                     {
-                        var array = source.Array;
-                        for (var index = 0; index < array.Length; index++)
+                        foreach (var item in source.Array)
                         {
-                            if (comparer.Equals(array![index], value!))
+                            if (comparer.Equals(item, value!))
                                 return true;
                         }
                     }
@@ -117,10 +114,9 @@ namespace NetFabric.Hyperlinq
                 {
                     if (source.IsWhole())
                     {
-                        var array = source.Array;
-                        for (var index = 0; index < array.Length; index++)
+                        foreach (var item in source.Array)
                         {
-                            if (EqualityComparer<TResult>.Default.Equals(selector(array![index])!, value!))
+                            if (EqualityComparer<TResult>.Default.Equals(selector(item)!, value!))
                                 return true;
                         }
                     }
@@ -146,10 +142,9 @@ namespace NetFabric.Hyperlinq
                 {
                     if (source.IsWhole())
                     {
-                        var array = source.Array;
-                        for (var index = 0; index < array.Length; index++)
+                        foreach (var item in source.Array)
                         {
-                            if (defaultComparer.Equals(selector(array![index])!, value!))
+                            if (defaultComparer.Equals(selector(item)!, value!))
                                 return true;
                         }
                     }
@@ -185,11 +180,13 @@ namespace NetFabric.Hyperlinq
                 {
                     if (source.IsWhole())
                     {
-                        var array = source.Array;
-                        for (var index = 0; index < array.Length; index++)
+                        var index = 0;
+                        foreach (var item in source.Array)
                         {
-                            if (EqualityComparer<TResult>.Default.Equals(selector(array![index], index)!, value!))
+                            if (EqualityComparer<TResult>.Default.Equals(selector(item, index)!, value!))
                                 return true;
+
+                            index++;
                         }
                     }
                     else
@@ -227,11 +224,13 @@ namespace NetFabric.Hyperlinq
                 {
                     if (source.IsWhole())
                     {
-                        var array = source.Array;
-                        for (var index = 0; index < array.Length; index++)
+                        var index = 0;
+                        foreach (var item in source.Array)
                         {
-                            if (defaultComparer.Equals(selector(array![index], index)!, value!))
+                            if (defaultComparer.Equals(selector(item, index)!, value!))
                                 return true;
+
+                            index++;
                         }
                     }
                     else

--- a/NetFabric.Hyperlinq/Set/Distinct/Distinct.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Set/Distinct/Distinct.ArraySegment.cs
@@ -90,9 +90,8 @@ namespace NetFabric.Hyperlinq
                 {
                     if (source.IsWhole())
                     {
-                        var array = source.Array;
-                        for (var index = 0; index < array.Length; index++)
-                            _ = set.Add(array![index]);
+                        foreach (var item in source.Array)
+                            _ = set.Add(item);
                     }
                     else
                     {

--- a/NetFabric.Hyperlinq/Utils/ArrayBuilder/ToArrayBuilder.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Utils/ArrayBuilder/ToArrayBuilder.ArraySegment.cs
@@ -16,10 +16,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        var item = array![index];
                         if (predicate(item))
                             builder.Add(item);
                     }
@@ -49,12 +47,13 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    var index = 0;
+                    foreach (var item in source.Array)
                     {
-                        var item = array![index];
                         if (predicate(item, index))
                             builder.Add(item);
+
+                        index++;
                     }
                 }
                 else
@@ -95,10 +94,8 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
+                    foreach (var item in source.Array)
                     {
-                        var item = array![index];
                         if (predicate(item))
                             builder.Add(selector(item));
                     }

--- a/NetFabric.Hyperlinq/Utils/Copy/Copy.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Utils/Copy/Copy.ArraySegment.cs
@@ -26,9 +26,12 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
-                        destination[index] = selector(array![index])!;
+                    var index = 0;
+                    foreach (var item in source.Array)
+                    {
+                        destination[index] = selector(item)!;
+                        index++;
+                    }
                 }
                 else
                 {
@@ -60,9 +63,12 @@ namespace NetFabric.Hyperlinq
             {
                 if (source.IsWhole())
                 {
-                    var array = source.Array;
-                    for (var index = 0; index < array.Length; index++)
-                        destination[index] = selector(array![index], index)!;
+                    var index = 0;
+                    foreach (var item in source.Array)
+                    {
+                        destination[index] = selector(item, index)!;
+                        index++;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
JIT can remove bound checking in the following cases:

``` csharp
public int Foreach()
{
    var sum = 0;
    foreach (var item in array)
        sum += item;
    return sum;
}
```

``` csharp
public int For()
{
    var sum = 0;
    var source = array;
    for (var index = 0; index < source.Length; index++)
        sum += source[index];
    return sum;
}
```

``` csharp
public int For(int start, int count)
{
    var sum = 0;
    var source = array;
    var end = start + count - 1;
    for (var index = start; index <= end; index++)
        sum += source[index];
    return sum;
}
```

I thought the first and second cases generated the same exact assembly code so, in a previous PR, I replaced all first cases by the second one. Today, I analyzed this again and found that the generated assembly is very similar but not exactly the same. The first case is consistently (slightly) faster in the benchmarks. I decided to revert the changes.

The third case is used when iterating a segment of the array.

