### PR TITLE
Use union struct instead of unsafe pointers

### DIFF
--- a/NetFabric.Hyperlinq/Aggregation/Count/Count.ArraySegment.cs
+++ b/NetFabric.Hyperlinq/Aggregation/Count/Count.ArraySegment.cs
@@ -11,7 +11,14 @@ namespace NetFabric.Hyperlinq
         public static int Count<TSource>(this in ArraySegment<TSource> source)
             => source.Count;
 
-        static unsafe int Count<TSource>(this in ArraySegment<TSource> source, Predicate<TSource> predicate)
+        [StructLayout(LayoutKind.Explicit)]
+        struct BoolInt32
+        {
+            [FieldOffset(0)] public bool Bool;
+            [FieldOffset(0)] public int Int32;
+        }
+
+        static int Count<TSource>(this in ArraySegment<TSource> source, Predicate<TSource> predicate)
         {
             var counter = 0;
             if (source.Any())
@@ -21,7 +28,7 @@ namespace NetFabric.Hyperlinq
                     foreach (var item in source.Array)
                     {
                         var result = predicate(item);
-                        counter += *(int*)&result;
+                        counter += new BoolInt32 { Bool = result }.Int32;
                     }
                 }
                 else
@@ -31,7 +38,7 @@ namespace NetFabric.Hyperlinq
                     for (var index = source.Offset; index <= end; index++)
                     {
                         var result = predicate(array![index]);
-                        counter += *(int*)&result;
+                        counter += new BoolInt32 { Bool = result }.Int32;
                     }
                 }
             }


### PR DESCRIPTION
Use union struct instead of unsafe pointers.
Inspired by the result of the following [benchmarks](https://github.com/ltrzesniewski/Benchmarks/blob/7529abb42e07cb5dad62744b9370655efc55cc58/Quick/Quick/AyendeSymbolSwitch.cs) published [here](https://ayende.com/blog/188353-A/writing-high-performance-code-despite-c).

```
Method                   | Count | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD | Gen 0 | Gen 1 | Gen 2 | Allocated
Hyperlinq_Array (main)   |   100 | 214.7 ns | 15.37 ns | 42.09 ns | 195.3 ns |     1 |       0 |     0 |     0 |     0 |       0 B
Hyperlinq_Array (branch) |   100 | 196.1 ns |  3.93 ns |  5.76 ns | 197.7 ns |  0.83 |    0.16 |     0 |     0 |     0 |       0 B
```