### PR TITLE
Added some Cistern.ValueLinq SelectMany benchmarks

### DIFF
--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/AllBenchmarks.CisternValueLinq.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/AllBenchmarks.CisternValueLinq.cs
@@ -70,6 +70,73 @@ namespace NetFabric.Hyperlinq.Benchmarks
             listReference
             .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
             .All(_ => true);
+
+        // ----
+
+        struct AlwaysTrue: IFunc<int, bool> { public bool Invoke(int _) => true; }
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_Array() =>
+            array
+            .OfArray() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_Span() =>
+            Enumerable
+            .FromSpan<int[], int>(array, array => array.AsSpan())
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_Memory() =>
+            memory
+            .OfMemory() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("Enumerable_Value")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_Enumerable_Value() =>
+            enumerableValue
+            .OfEnumeratorConstraint<int, TestEnumerable.Enumerable, TestEnumerable.Enumerable.Enumerator>(x => x.GetEnumerator())
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("Collection_Value")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_Collection_Value() =>
+            collectionValue
+            .OfEnumeratorConstraint<int, TestCollection.Enumerable, TestCollection.Enumerable.Enumerator>(x => x.GetEnumerator(), collectionValue.Count)
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("List_Value")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_List_Value() =>
+            listValue
+            .OfReadOnlyListConstraint<int, TestList.Enumerable>()
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("Enumerable_Reference")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_Enumerable_Reference() =>
+            enumerableReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("Collection_Reference")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_Collection_Reference() =>
+            collectionReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(new AlwaysTrue());
+
+        [BenchmarkCategory("List_Reference")]
+        [Benchmark]
+        public bool CisternValueLinq_ValueLambda_List_Reference() =>
+            listReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(new AlwaysTrue());
     }
 }
 

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/AllBenchmarks.CisternValueLinq.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/AllBenchmarks.CisternValueLinq.cs
@@ -1,0 +1,76 @@
+#if !(NETCOREAPP2_1 || NET48)
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+using System;
+
+namespace NetFabric.Hyperlinq.Benchmarks
+{
+    public partial class AllBenchmarks : RandomBenchmarksBase
+    {
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public bool CisternValueLinq_Array() =>
+            array
+            .OfArray() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(_ => true);
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public bool CisternValueLinq_Span() =>
+            Enumerable
+            .FromSpan<int[], int>(array, array => array.AsSpan())
+            .All(_ => true);
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public bool CisternValueLinq_Memory() =>
+            memory
+            .OfMemory() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(_ => true);
+
+        [BenchmarkCategory("Enumerable_Value")]
+        [Benchmark]
+        public bool CisternValueLinq_Enumerable_Value() =>
+            enumerableValue
+            .OfEnumeratorConstraint<int, TestEnumerable.Enumerable, TestEnumerable.Enumerable.Enumerator>(x => x.GetEnumerator())
+            .All(_ => true);
+
+        [BenchmarkCategory("Collection_Value")]
+        [Benchmark]
+        public bool CisternValueLinq_Collection_Value() =>
+            collectionValue
+            .OfEnumeratorConstraint<int, TestCollection.Enumerable, TestCollection.Enumerable.Enumerator>(x => x.GetEnumerator(), collectionValue.Count)
+            .All(_ => true);
+
+        [BenchmarkCategory("List_Value")]
+        [Benchmark]
+        public bool CisternValueLinq_List_Value() =>
+            listValue
+            .OfReadOnlyListConstraint<int, TestList.Enumerable>()
+            .All(_ => true);
+
+        [BenchmarkCategory("Enumerable_Reference")]
+        [Benchmark]
+        public bool CisternValueLinq_Enumerable_Reference() =>
+            enumerableReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(_ => true);
+
+        [BenchmarkCategory("Collection_Reference")]
+        [Benchmark]
+        public bool CisternValueLinq_Collection_Reference() =>
+            collectionReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(_ => true);
+
+        [BenchmarkCategory("List_Reference")]
+        [Benchmark]
+        public bool CisternValueLinq_List_Reference() =>
+            listReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .All(_ => true);
+    }
+}
+
+#endif

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/AllBenchmarks.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/AllBenchmarks.cs
@@ -8,7 +8,7 @@ namespace NetFabric.Hyperlinq.Benchmarks
 {
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]
-    public class AllBenchmarks : RandomBenchmarksBase
+    public partial class AllBenchmarks : RandomBenchmarksBase
     {
         [BenchmarkCategory("Array")]
         [Benchmark(Baseline = true)]

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/SelectManyBenchmarks.CisternValueLinq.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/SelectManyBenchmarks.CisternValueLinq.cs
@@ -1,0 +1,72 @@
+#if !(NETCOREAPP2_1 || NET48)
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+
+namespace NetFabric.Hyperlinq.Benchmarks
+{
+    public partial class SelectManyBenchmarks : RandomBenchmarksBase
+    {
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public int CisternValueLinq_Array() =>
+            array
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public int CisternValueLinq_Memory() =>
+            memory
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+
+        [BenchmarkCategory("Enumerable_Value")]
+        [Benchmark]
+        public int CisternValueLinq_Enumerable_Value() =>
+            enumerableValue
+            .OfEnumeratorConstraint<int, TestEnumerable.Enumerable, TestEnumerable.Enumerable.Enumerator>(x => x.GetEnumerator())
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+
+        [BenchmarkCategory("Collection_Value")]
+        [Benchmark]
+        public int CisternValueLinq_Collection_Value() =>
+            collectionValue
+            .OfEnumeratorConstraint<int, TestCollection.Enumerable, TestCollection.Enumerable.Enumerator>(x => x.GetEnumerator(), collectionValue.Count)
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+
+        [BenchmarkCategory("List_Value")]
+        [Benchmark]
+        public int CisternValueLinq_List_Value() =>
+            listValue
+            .OfReadOnlyListConstraint<int, TestList.Enumerable>()
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+
+        [BenchmarkCategory("Enumerable_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_Enumerable_Reference() =>
+            enumerableReference
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+
+        [BenchmarkCategory("Collection_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_Collection_Reference() =>
+            collectionReference
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+
+        [BenchmarkCategory("List_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_List_Reference() =>
+            listReference
+            .SelectMany(item => Enumerable.Return(item))
+            .Sum();
+    }
+}
+
+#endif

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/SelectManyBenchmarks.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/SelectManyBenchmarks.cs
@@ -7,7 +7,7 @@ namespace NetFabric.Hyperlinq.Benchmarks
 {
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]
-    public class SelectManyBenchmarks : RandomBenchmarksBase
+    public partial class SelectManyBenchmarks : RandomBenchmarksBase
     {
         [BenchmarkCategory("Array")]
         [Benchmark(Baseline = true)]

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.CisternValueLinq.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.CisternValueLinq.cs
@@ -65,6 +65,7 @@ namespace NetFabric.Hyperlinq.Benchmarks
         [Benchmark]
         public int CisternValueLinq_Enumerable_Reference() =>
             enumerableReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
             .Where(item => (item & 0x01) == 0)
             .Select(item => item)
             .Sum();
@@ -73,6 +74,7 @@ namespace NetFabric.Hyperlinq.Benchmarks
         [Benchmark]
         public int CisternValueLinq_Collection_Reference() =>
             collectionReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
             .Where(item => (item & 0x01) == 0)
             .Select(item => item)
             .Sum();
@@ -81,6 +83,7 @@ namespace NetFabric.Hyperlinq.Benchmarks
         [Benchmark]
         public int CisternValueLinq_List_Reference() =>
             listReference
+            .OfEnumerable() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
             .Where(item => (item & 0x01) == 0)
             .Select(item => item)
             .Sum();

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.CisternValueLinq.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.CisternValueLinq.cs
@@ -1,0 +1,135 @@
+#if !(NETCOREAPP2_1 || NET48)
+
+using BenchmarkDotNet.Attributes;
+using Cistern.ValueLinq;
+
+namespace NetFabric.Hyperlinq.Benchmarks
+{
+    public partial class WhereSelectBenchmarks: RandomBenchmarksBase
+    {
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public int CisternValueLinq_Array() =>
+            array
+            .OfArray() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("Enumerable_Value")]
+        [Benchmark]
+        public int CisternValueLinq_Enumerable_Value() =>
+            enumerableValue
+            .OfEnumeratorConstraint<int, TestEnumerable.Enumerable, TestEnumerable.Enumerable.Enumerator>(x => x.GetEnumerator())
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("Collection_Value")]
+        [Benchmark]
+        public int CisternValueLinq_Collection_Value() =>
+            collectionValue
+            .OfEnumeratorConstraint<int, TestCollection.Enumerable, TestCollection.Enumerable.Enumerator>(x => x.GetEnumerator(), collectionValue.Count)
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("List_Value")]
+        [Benchmark]
+        public int CisternValueLinq_List_Value() =>
+            listValue
+            .OfReadOnlyListConstraint<int, TestList.Enumerable>()
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("Enumerable_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_Enumerable_Reference() =>
+            enumerableReference
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("Collection_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_Collection_Reference() =>
+            collectionReference
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("List_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_List_Reference() =>
+            listReference
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        // ------
+
+        struct IsEven : IFunc<int, bool> { public bool Invoke(int item) => (item & 0x01) == 0; }
+        struct Identity : IFunc<int, int> { public int Invoke(int item) => item; }
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public int CisternValueLinq_ValueLambda_Array() =>
+            array
+            .Where(new IsEven())
+            .Select(new Identity(), default(int))
+            .Sum();
+
+        [BenchmarkCategory("Enumerable_Value")]
+        [Benchmark]
+        public int CisternValueLinq_ValueLambda_Enumerable_Value() =>
+            enumerableValue
+            .OfEnumeratorConstraint<int, TestEnumerable.Enumerable, TestEnumerable.Enumerable.Enumerator>(x => x.GetEnumerator())
+            .Where(new IsEven())
+            .Select(new Identity(), default(int))
+            .Sum();
+
+        [BenchmarkCategory("Collection_Value")]
+        [Benchmark]
+        public int CisternValueLinq_ValueLambda_Collection_Value() =>
+            collectionValue
+            .OfEnumeratorConstraint<int, TestCollection.Enumerable, TestCollection.Enumerable.Enumerator>(x => x.GetEnumerator(), collectionValue.Count)
+            .Where(new IsEven())
+            .Select(new Identity(), default(int))
+            .Sum();
+
+        [BenchmarkCategory("List_Value")]
+        [Benchmark]
+        public int CisternValueLinq_ValueLambda_List_Value() =>
+            listValue
+            .OfReadOnlyListConstraint<int, TestList.Enumerable>()
+            .Where(new IsEven())
+            .Select(new Identity(), default(int))
+            .Sum();
+
+        [BenchmarkCategory("Enumerable_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_ValueLambda_Enumerable_Reference() =>
+            enumerableReference
+            .Where(new IsEven())
+            .Select(new Identity(), default(int))
+            .Sum();
+
+        [BenchmarkCategory("Collection_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_ValueLambda_Collection_Reference() =>
+            collectionReference
+            .Where(new IsEven())
+            .Select(new Identity(), default(int))
+            .Sum();
+
+        [BenchmarkCategory("List_Reference")]
+        [Benchmark]
+        public int CisternValueLinq_ValueLambda_List_Reference() =>
+            listReference
+            .Where(new IsEven())
+            .Select(new Identity(), default(int))
+            .Sum();
+    }
+}
+#endif

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.CisternValueLinq.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.CisternValueLinq.cs
@@ -2,6 +2,7 @@
 
 using BenchmarkDotNet.Attributes;
 using Cistern.ValueLinq;
+using System;
 
 namespace NetFabric.Hyperlinq.Benchmarks
 {
@@ -12,6 +13,23 @@ namespace NetFabric.Hyperlinq.Benchmarks
         public int CisternValueLinq_Array() =>
             array
             .OfArray() // *shouldn't* need this!!! only because we are in the NetFabric.Hyperlinq namespace; so c# chooses incorrect overload
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public int CisternValueLinq_Span() =>
+            Enumerable
+            .FromSpan<int[], int>(array, array => array.AsSpan())
+            .Where(item => (item & 0x01) == 0)
+            .Select(item => item)
+            .Sum();
+
+        [BenchmarkCategory("Array")]
+        [Benchmark]
+        public int CisternValueLinq_Memory() =>
+            memory
             .Where(item => (item & 0x01) == 0)
             .Select(item => item)
             .Sum();

--- a/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.cs
+++ b/NetFabric.Hyperlinq.Benchmarks/Benchmarks/WhereSelectBenchmarks.cs
@@ -8,7 +8,7 @@ namespace NetFabric.Hyperlinq.Benchmarks
 {
     [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
     [CategoriesColumn]
-    public class WhereSelectBenchmarks: RandomBenchmarksBase
+    public partial class WhereSelectBenchmarks: RandomBenchmarksBase
     {
         [BenchmarkCategory("Array")]
         [Benchmark(Baseline = true)]

--- a/NetFabric.Hyperlinq.Benchmarks/NetFabric.Hyperlinq.Benchmarks.csproj
+++ b/NetFabric.Hyperlinq.Benchmarks/NetFabric.Hyperlinq.Benchmarks.csproj
@@ -26,13 +26,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Cistern.ValueLinq">
-      <Version>0.0.3</Version>
+      <Version>0.0.4</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Cistern.ValueLinq">
-      <Version>0.0.3</Version>
+      <Version>0.0.4</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/NetFabric.Hyperlinq.Benchmarks/NetFabric.Hyperlinq.Benchmarks.csproj
+++ b/NetFabric.Hyperlinq.Benchmarks/NetFabric.Hyperlinq.Benchmarks.csproj
@@ -23,4 +23,16 @@
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0-rc.1.20451.14" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Cistern.ValueLinq">
+      <Version>0.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Cistern.ValueLinq">
+      <Version>0.0.3</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/NetFabric.Hyperlinq.Benchmarks/NetFabric.Hyperlinq.Benchmarks.csproj
+++ b/NetFabric.Hyperlinq.Benchmarks/NetFabric.Hyperlinq.Benchmarks.csproj
@@ -26,13 +26,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Cistern.ValueLinq">
-      <Version>0.0.4</Version>
+      <Version>0.0.5</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Cistern.ValueLinq">
-      <Version>0.0.4</Version>
+      <Version>0.0.5</Version>
     </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Hi!

I've been working on _yet another_ value based linq.

But I think this one has some special features that make it quite nice.

So you don't need to annotate any of the functions with the Enumerator type, as it's all hidden. You can compose components together stepping through IEnumerable<> and still get the performance benefits. It's basically "code compatible" with existing Linq (i.e. you should just be able to change `using System.Linq` to `using Cistern.ValueLinq` and it (cough) should work.

It's weakness is in accessing the Enumerator from the outside (i.e. in a `foreach`) but it's not _terrible_ (but really it's intent is to use the aggregation functions)

But still very, very much a WIP.

Anyway, this was the first stop I was making in your benchmarks, as most of them don't really seem to be composing things, so thought I'd give it a crack.

Here's benchmark results from my machine - I didn't add them to the change-set, as my crappy old machine (12 years old?) was vastly different performance profile, so thought you should.

Oh, and it's .netstandard2.1 (not 100% sure I have to be? I don't know) which didn't like running, I'm not very familiar with multiple frameworks, so I just cut all but .net5.0 out when I was running the test suite (but obviously didn't check that in)

ValueLinq is [here](https://github.com/manofstick/Cistern.ValueLinq)



|                                Method |                Categories | Count |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------------- |-------------------------- |------ |----------:|----------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
|                CisternValueLinq_Array |                     Array |   100 |  1.656 us | 0.0084 us | 0.0074 us |  1.652 us |  0.10 |    0.03 | 0.0057 |     - |     - |      24 B |
|               CisternValueLinq_Memory |                     Array |   100 |  1.569 us | 0.0025 us | 0.0019 us |  1.569 us |  0.09 |    0.03 | 0.0057 |     - |     - |      24 B |
|                            Linq_Array |                     Array |   100 | 16.365 us | 1.6523 us | 4.7935 us | 13.400 us |  1.00 |    0.00 |      - |     - |     - |    4096 B |
|                       Hyperlinq_Array |                     Array |   100 |  2.088 us | 0.0418 us | 0.0573 us |  2.113 us |  0.13 |    0.03 |      - |     - |     - |         - |
|                      Hyperlinq_Memory |                     Array |   100 |  2.282 us | 0.0455 us | 0.0623 us |  2.311 us |  0.14 |    0.04 |      - |     - |     - |         - |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
|     CisternValueLinq_Enumerable_Value |          Enumerable_Value |   100 |  1.591 us | 0.0098 us | 0.0082 us |  1.589 us |  0.23 |    0.01 | 0.0057 |     - |     - |      24 B |
|                 Linq_Enumerable_Value |          Enumerable_Value |   100 |  7.029 us | 0.1386 us | 0.2704 us |  7.096 us |  1.00 |    0.00 | 0.9766 |     - |     - |    4096 B |
|            Hyperlinq_Enumerable_Value |          Enumerable_Value |   100 |  2.031 us | 0.0402 us | 0.0765 us |  2.070 us |  0.29 |    0.02 |      - |     - |     - |         - |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
|     CisternValueLinq_Collection_Value |          Collection_Value |   100 |  1.622 us | 0.0285 us | 0.0267 us |  1.621 us |  0.22 |    0.01 | 0.0057 |     - |     - |      24 B |
|                 Linq_Collection_Value |          Collection_Value |   100 |  7.561 us | 0.1495 us | 0.3638 us |  7.624 us |  1.00 |    0.00 | 0.9766 |     - |     - |    4096 B |
|            Hyperlinq_Collection_Value |          Collection_Value |   100 |  2.024 us | 0.0402 us | 0.0765 us |  2.050 us |  0.27 |    0.02 |      - |     - |     - |         - |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
|           CisternValueLinq_List_Value |                List_Value |   100 |  1.771 us | 0.0354 us | 0.0379 us |  1.771 us |  0.23 |    0.01 | 0.0057 |     - |     - |      24 B |
|                       Linq_List_Value |                List_Value |   100 |  7.565 us | 0.1502 us | 0.3656 us |  7.613 us |  1.00 |    0.00 | 0.9766 |     - |     - |    4096 B |
|                  Hyperlinq_List_Value |                List_Value |   100 |  2.145 us | 0.0424 us | 0.0594 us |  2.184 us |  0.28 |    0.01 |      - |     - |     - |         - |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
| CisternValueLinq_Enumerable_Reference |      Enumerable_Reference |   100 |  2.324 us | 0.0455 us | 0.0708 us |  2.330 us |  0.32 |    0.02 | 0.0114 |     - |     - |      56 B |
|             Linq_Enumerable_Reference |      Enumerable_Reference |   100 |  7.155 us | 0.1399 us | 0.2695 us |  7.204 us |  1.00 |    0.00 | 0.9766 |     - |     - |    4096 B |
|        Hyperlinq_Enumerable_Reference |      Enumerable_Reference |   100 |  2.470 us | 0.0493 us | 0.1237 us |  2.510 us |  0.35 |    0.02 | 0.0076 |     - |     - |      32 B |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
| CisternValueLinq_Collection_Reference |      Collection_Reference |   100 |  2.165 us | 0.0427 us | 0.0714 us |  2.182 us |  0.30 |    0.02 | 0.0114 |     - |     - |      56 B |
|             Linq_Collection_Reference |      Collection_Reference |   100 |  7.141 us | 0.1420 us | 0.2868 us |  7.236 us |  1.00 |    0.00 | 0.9766 |     - |     - |    4096 B |
|        Hyperlinq_Collection_Reference |      Collection_Reference |   100 |  2.474 us | 0.0495 us | 0.1107 us |  2.497 us |  0.35 |    0.02 | 0.0076 |     - |     - |      32 B |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
|       CisternValueLinq_List_Reference |            List_Reference |   100 |  2.204 us | 0.0439 us | 0.0643 us |  2.220 us |  0.30 |    0.02 | 0.0114 |     - |     - |      56 B |
|                   Linq_List_Reference |            List_Reference |   100 |  7.243 us | 0.1446 us | 0.2786 us |  7.296 us |  1.00 |    0.00 | 0.9766 |     - |     - |    4096 B |
|              Hyperlinq_List_Reference |            List_Reference |   100 |  2.123 us | 0.0424 us | 0.0904 us |  2.140 us |  0.29 |    0.02 |      - |     - |     - |         - |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
|            Linq_AsyncEnumerable_Value |     AsyncEnumerable_Value |   100 | 42.323 us | 1.6106 us | 4.5427 us | 40.500 us |  1.00 |    0.00 |      - |     - |     - |    4984 B |
|                                       |                           |       |           |           |           |           |       |         |        |       |       |           |
|        Linq_AsyncEnumerable_Reference | AsyncEnumerable_Reference |   100 | 23.955 us | 0.4781 us | 1.0084 us | 24.158 us |  1.00 |    0.00 | 1.1902 |     - |     - |    4984 B |