### PR TITLE
Remove NoInliningAttribute for Throw methods

### DIFF
--- a/NetFabric.Hyperlinq/Utils/Throw.cs
+++ b/NetFabric.Hyperlinq/Utils/Throw.cs
@@ -8,102 +8,82 @@ namespace NetFabric.Hyperlinq
     static class Throw
     {
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ArgumentArraySegmentNullException(string paramName)
             => throw new ArgumentException(paramName: paramName, message: Resource.ArraySegmentNull);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ArgumentException(string paramName, string? message = default)
             => throw new ArgumentException(paramName: paramName, message: message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ArgumentNullException(string paramName, string? message = default)
             => throw new ArgumentNullException(paramName: paramName, message: message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T ArgumentNullException<T>(string paramName, string? message = default)
             => throw new ArgumentNullException(paramName: paramName, message: message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static ref readonly T ArgumentNullExceptionRef<T>(string paramName, string? message = default)
             => throw new ArgumentNullException(paramName: paramName, message: message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ArgumentOutOfRangeException(string paramName, string? message = default)
             => throw new ArgumentOutOfRangeException(paramName: paramName, message: message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T ArgumentOutOfRangeException<T>(string paramName, string? message = default)
             => throw new ArgumentOutOfRangeException(paramName: paramName, message: message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static ref readonly T ArgumentOutOfRangeExceptionRef<T>(string paramName, string? message = default)
             => throw new ArgumentOutOfRangeException(paramName: paramName, message: message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void EmptySequence()
             => throw new InvalidOperationException(Resource.EmptySequence);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T EmptySequence<T>()
             => throw new InvalidOperationException(Resource.EmptySequence);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static ref readonly T EmptySequenceRef<T>()
             => throw new InvalidOperationException(Resource.EmptySequence);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void NotSingleSequence()
             => throw new InvalidOperationException(Resource.NotSingleSequence);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T NotSingleSequence<T>()
             => throw new InvalidOperationException(Resource.NotSingleSequence);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static ref readonly T NotSingleSequenceRef<T>()
             => throw new InvalidOperationException(Resource.NotSingleSequence);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void InvalidOperationException(string? message = default)
             => throw new InvalidOperationException(message);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T InvalidOperationException<T>()
             => throw new InvalidOperationException();
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void NotSupportedException()
             => throw new NotSupportedException();
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T NotSupportedException<T>()
             => throw new NotSupportedException();
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ObjectDisposedException(string objectName)
             => throw new ObjectDisposedException(objectName);
 
         [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public static T ObjectDisposedException<T>(string objectName)
             => throw new ObjectDisposedException(objectName);
     }


### PR DESCRIPTION
[JIT optimizes better if attribute not used](https://github.com/CommunityToolkit/WindowsCommunityToolkit/pull/3367#issuecomment-651690818)